### PR TITLE
feat: switch to alloy-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2021"
 
 [dependencies]
 bs58 = "0.5.0"
-ethers-core = { version = "2.0.8", default-features = false, features = [] }
+alloy-primitives = { version = "0.3.1", features = ["serde"] }
 firestorm = { version = "0.5.1", optional = true }
 graphql-parser = { version = "0.4.0", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
 sha3 = "0.10.6"
 url = { version = "2.4.0", optional = true }
+serde_with = "3.2.0"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toolshed"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/thegraph/mod.rs
+++ b/src/thegraph/mod.rs
@@ -1,4 +1,4 @@
-use std::{cmp, fmt, str::FromStr};
+use std::{fmt, str::FromStr};
 
 use ethers_core::{
     abi::Hash,
@@ -10,19 +10,13 @@ use sha3::{
     Keccak256,
 };
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BlockPointer {
     pub number: u64,
     pub hash: Hash,
 }
 
-impl PartialOrd for BlockPointer {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.number.partial_cmp(&other.number)
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubgraphId(pub H256);
 
 impl FromStr for SubgraphId {
@@ -73,7 +67,7 @@ impl fmt::Debug for SubgraphId {
 }
 
 /// subgraph deployment hash, encoded/decoded using its CIDv0 representation
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeploymentId(pub H256);
 
 impl FromStr for DeploymentId {


### PR DESCRIPTION
[Alloy](https://www.paradigm.xyz/2023/06/alloy) is the foundation for a rewrite of ethers-rs. It's primitive types (especially `FixedBytes`) are much nicer to work with. This also fixes up some impls that I missed when switching to ethers.