### PR TITLE
chore(ci): update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,71 +1,97 @@
-name: Continuous Integration
-
+name: ci
 on:
-  push:
-    branches: [master]
   pull_request:
-    types: [opened, synchronize, reopened]
+  push:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
 
 jobs:
-  unit-tests:
-    name: unit tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v2
-      - name: unit tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --workspace -- --nocapture
-
   rustfmt:
-    name: rustfmt
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-
-      - name: rustfmt
-        uses: actions-rs/cargo@v1
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: fmt
-          args: --all -- --check
+          toolchain: stable
+          components: rustfmt
+
+      - name: Cache rust cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
+        with:
+          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
+      - run: cargo fmt --all -- --check
 
   clippy:
-    name: clippy
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v2
-      - name: clippy
-        uses: actions-rs/cargo@v1
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: clippy
+          toolchain: stable
+          components: clippy
+
+      - name: Cache rust cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
+        with:
+          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
+      - run: cargo clippy --all --all-targets --all-features
 
   release-check:
-    name: release check
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v2
-      - name: release check
-        uses: actions-rs/cargo@v1
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: check
-          args: --release
+          toolchain: stable
+
+      - name: Cache rust cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
+        with:
+          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
+      - name: check (release)
+        run: cargo check --release --all --all-targets --all-features
+
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache rust cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
+        with:
+          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
+      - name: Unit tests
+        run: cargo test --verbose --workspace --lib -- --nocapture
+
+      - name: Integration tests
+        run: cargo test --verbose --workspace --tests '*' -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Cache rust cargo build files
         uses: Leafwing-Studios/cargo-cache@v1
-        with:
-          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
       - run: cargo fmt --all -- --check
 
@@ -48,8 +46,6 @@ jobs:
 
       - name: Cache rust cargo build files
         uses: Leafwing-Studios/cargo-cache@v1
-        with:
-          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
       - run: cargo clippy --all --all-targets --all-features
 
@@ -67,8 +63,6 @@ jobs:
 
       - name: Cache rust cargo build files
         uses: Leafwing-Studios/cargo-cache@v1
-        with:
-          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
       - name: check (release)
         run: cargo check --release --all --all-targets --all-features
@@ -87,8 +81,6 @@ jobs:
 
       - name: Cache rust cargo build files
         uses: Leafwing-Studios/cargo-cache@v1
-        with:
-          cache-group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
       - name: Unit tests
         run: cargo test --verbose --workspace --lib -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
-/target
-/Cargo.lock
+## IDEs and Editors
+.idea/
+.vscode/
+
+## Rust
+debug/
+target/
+**/*.rs.bk
+Cargo.lock
+*.pdb
+
+## Project
+test-outputs/


### PR DESCRIPTION
This PR updates the CI workflow with the latest GH action versions (e.g., the checkout action) and uses the same actions used in other edge & node rust projects (e.g., rust toolchain and cargo cache).

Additionally, this PR updates the `.gitignore` file.