### PR TITLE
feat(graphql): add graphql-over-http client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: Leafwing-Studios/cargo-cache@5edda26afa3d28be5d6ee87d4c69c246e3ee37fb # v1
 
       - name: Unit tests
-        run: cargo test --verbose --workspace --lib -- --nocapture
+        run: cargo test --verbose --workspace --all-features --lib -- --nocapture
 
       - name: Integration tests
-        run: cargo test --verbose --workspace --tests '*' -- --nocapture
+        run: cargo test --verbose --workspace --all-features --tests '*' -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
     "toolshed",
     "graphql",
+    "graphql-http"
 ]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ services.
     ```toml
     graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.1.0" }
     ```
+* **graphql-http:** A _reqwest_ based GraphQL-over-HTTP client.
+
+    ```toml
+    graphql-http = { git = "https://github.com/eandn/toolshed", tag = "graphql-http-v0.1.0" }
+    ```

--- a/graphql-http/Cargo.toml
+++ b/graphql-http/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "graphql-http"
+description = "A reqwest based GraphQL-over-HTTP client"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.63.0"
+
+[features]
+http-reqwest = ["dep:async-trait", "dep:thiserror", "dep:reqwest"]
+compat-graphql-client = ["dep:graphql_client"]
+compat-graphql-parser = ["dep:graphql-parser"]
+
+[dependencies]
+anyhow = "1.0.75"
+async-trait = { version = "0.1", optional = true }
+graphql-parser = { version = "0.4.0", optional = true }
+graphql_client = { version = "0.13.0", optional = true }
+reqwest = { version = "0.11", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = { version = "1.0", optional = true }
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+indoc = "2.0.4"
+tokio = { version = "1.32", features = ["rt", "macros", "time"] }

--- a/graphql-http/README.md
+++ b/graphql-http/README.md
@@ -1,0 +1,9 @@
+GraphQL-over-HTTP
+=================
+
+A _reqwest_ based GraphQL-over-HTTP client compatible with `graphql-parser` and `graphql-client` crates. See the 
+crate documentation for more details.
+
+```
+graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-vX.Y.Z" }
+```

--- a/graphql-http/src/compat.rs
+++ b/graphql-http/src/compat.rs
@@ -1,0 +1,57 @@
+#[cfg(feature = "compat-graphql-parser")]
+pub mod compat_graphql_parser {
+    use graphql_parser::query::Text;
+
+    use crate::graphql::{Document, IntoDocument};
+
+    // Implement `IntoRequestParameters` for `graphql_parser::query::Document` so that we can use
+    // `graphql_parser` to parse GraphQL queries.
+    //
+    // As any type implementing `IntoQuery` also implements `IntoRequestParameters`, this allows us to
+    // seamlessly support `graphql_parser` generated queries.
+    impl<'a, T: Text<'a>> IntoDocument for graphql_parser::query::Document<'a, T> {
+        fn into_document(self) -> Document {
+            Document::new(self.to_string())
+        }
+    }
+}
+
+#[cfg(feature = "compat-graphql-client")]
+pub mod compat_graphql_client {
+    use graphql_client::QueryBody;
+
+    use crate::graphql::IntoDocument;
+    use crate::http::request::{IntoRequestParameters, RequestParameters};
+
+    // Implement `IntoRequestParameters` for `graphql_client::QueryBody` so that we can seamlessly
+    // support `graphql_client` generated queries.
+    impl<V> IntoRequestParameters for QueryBody<V>
+    where
+        V: serde::ser::Serialize,
+    {
+        fn into_request_parameters(self) -> RequestParameters {
+            let query = self.query.into_document();
+
+            // Do not send the `operation_name` field if it is empty.
+            let operation_name = if !self.operation_name.is_empty() {
+                Some(self.operation_name.to_owned())
+            } else {
+                None
+            };
+
+            // Do not send the `variables` field if the json serialization fails, or if the
+            // serialization result is not a JSON object.
+            let variables = match serde_json::to_value(self.variables) {
+                Ok(serde_json::Value::Object(vars)) => Some(vars),
+                _ => None,
+            };
+
+            RequestParameters {
+                query,
+                operation_name,
+                variables: variables.unwrap_or_default(),
+                extensions: Default::default(),
+            }
+        }
+    }
+}

--- a/graphql-http/src/graphql.rs
+++ b/graphql-http/src/graphql.rs
@@ -1,0 +1,85 @@
+//! GraphQL query type and related traits.
+//!
+//! This module contains the [`Document`] type and the [`IntoDocument`] conversion trait. The conversion
+//! trait is implemented for string types: [`String`] and `&str`.
+//!
+
+/// A (raw) GraphQL request document.
+///
+/// This type is a wrapper around a string that represents a GraphQL request document. This type
+/// does not perform any validation on the string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document(String);
+
+impl Document {
+    /// Create a new GraphQL [`Document`] instance from a `String`.
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Return a string slice to the document.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for Document {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl std::fmt::Display for Document {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl serde::ser::Serialize for Document {
+    fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+/// A trait for types that can be converted into a [`Document`].
+pub trait IntoDocument {
+    /// Consumes `self` and returns a [`Document`].
+    fn into_document(self) -> Document;
+}
+
+/// A trait for types that can be converted into a [`Document`] and variables tuple.
+pub trait IntoDocumentWithVariables {
+    type Variables: serde::Serialize;
+
+    /// Consumes `self` and returns a query and variables tuple.
+    fn into_document_with_variables(self) -> (Document, Self::Variables);
+}
+
+impl IntoDocument for Document {
+    fn into_document(self) -> Document {
+        self
+    }
+}
+
+impl IntoDocument for String {
+    fn into_document(self) -> Document {
+        Document(self)
+    }
+}
+
+impl IntoDocument for &str {
+    fn into_document(self) -> Document {
+        Document(self.to_owned())
+    }
+}
+
+impl<T> IntoDocumentWithVariables for T
+where
+    T: IntoDocument,
+{
+    type Variables = ();
+
+    fn into_document_with_variables(self) -> (Document, Self::Variables) {
+        (self.into_document(), ())
+    }
+}

--- a/graphql-http/src/http.rs
+++ b/graphql-http/src/http.rs
@@ -1,0 +1,2 @@
+pub mod request;
+pub mod response;

--- a/graphql-http/src/http/request.rs
+++ b/graphql-http/src/http/request.rs
@@ -1,0 +1,66 @@
+use crate::graphql::{Document, IntoDocumentWithVariables};
+
+/// The media type for GraphQL-over-HTTP requests. As specified in the section
+/// [4.1 Media Types](https://graphql.github.io/graphql-over-http/draft/#sec-Media-Types)
+/// of the GraphQL-over-HTTP specification.
+pub const GRAPHQL_REQUEST_MEDIA_TYPE: &str = "application/json";
+
+/// The parameters of a GraphQL-over-HTTP request.
+///
+/// As specified in the section [5.1 Request Parameters](https://graphql.github.io/graphql-over-http/draft/#sec-Request-Parameters)
+/// of the GraphQL-over-HTTP specification.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RequestParameters {
+    /// The string representation of the Source Text of a GraphQL Document as specified in [the
+    /// Language section of the GraphQL specification](https://spec.graphql.org/draft/#sec-Language).
+    pub query: Document,
+
+    /// Optional name of the operation in the Document to execute.
+    #[serde(rename = "operationName", skip_serializing_if = "Option::is_none")]
+    pub operation_name: Option<String>,
+
+    /// Values for any Variables defined by the Operation.
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    pub variables: serde_json::Map<String, serde_json::Value>,
+
+    /// Reserved for implementors to extend the protocol however they see fit.
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extensions: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Convert `self` into a `RequestParameters` struct.
+pub trait IntoRequestParameters {
+    /// Consumes `self` and returns a `RequestParameters` struct.
+    fn into_request_parameters(self) -> RequestParameters;
+}
+
+impl IntoRequestParameters for RequestParameters {
+    fn into_request_parameters(self) -> RequestParameters {
+        self
+    }
+}
+
+// Any type implementing `IntoQueryWithVariables` (or `IntoQuery`) can be converted into
+// `RequestParameters`.
+impl<T> IntoRequestParameters for T
+where
+    T: IntoDocumentWithVariables,
+{
+    fn into_request_parameters(self) -> RequestParameters {
+        let (query, variables) = self.into_document_with_variables();
+
+        // Do not send the `variables` field if the json serialization fails, or if the
+        // serialization result is not a JSON object.
+        let variables = match serde_json::to_value(variables) {
+            Ok(serde_json::Value::Object(vars)) => Some(vars),
+            _ => None,
+        };
+
+        RequestParameters {
+            query,
+            operation_name: None,
+            variables: variables.unwrap_or_default(),
+            extensions: Default::default(),
+        }
+    }
+}

--- a/graphql-http/src/http/response.rs
+++ b/graphql-http/src/http/response.rs
@@ -1,0 +1,88 @@
+/// The preferred type for GraphQL-over-HTTP server responses. As specified in the section
+/// [4.1 Media Types](https://graphql.github.io/graphql-over-http/draft/#sec-Media-Types) of the
+/// GraphQL-over-HTTP specification.
+pub const GRAPHQL_RESPONSE_MEDIA_TYPE: &str = "application/graphql-response+json";
+
+/// The legacy type for GraphQL-over-HTTP server responses. As specified in the section
+/// [4.1 Media Types](https://graphql.github.io/graphql-over-http/draft/#sec-Media-Types) of the
+/// GraphQL-over-HTTP specification.
+pub const GRAPHQL_LEGACY_RESPONSE_MEDIA_TYPE: &str = "application/json";
+
+/// The response error type for GraphQL-over-HTTP server responses. As specified in the section
+/// [7.1.2 Errors](https://spec.graphql.org/draft/#sec-Errors) and the
+/// [Error Result Format](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format) subsection
+/// of the GraphQL specification.
+#[derive(Debug, serde::Deserialize)]
+pub struct Error {
+    /// A short, human-readable description of the problem.
+    ///
+    /// From the [Error Result Format](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format)
+    /// subsection of the GraphQL specification:
+    ///
+    /// > Every error MUST contain an entry with the key `message` with a string description of the
+    /// > error intended for the developer as a guide to understand and correct the error.
+    pub message: String,
+
+    /// A list of locations describing the beginning of the associated syntax element causing the
+    /// error.
+    ///
+    /// From the [Error Result Format](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format)
+    /// subsection of the GraphQL specification:
+    ///
+    /// > If an error can be associated to a particular point in the requested GraphQL document, it
+    /// > SHOULD contain an entry with the key `locations` with a list of locations, where each
+    /// > location is a map with the keys `line` and `column`, both positive numbers starting from
+    /// `1` which describe the beginning of an associated syntax element.
+    #[serde(default)]
+    pub locations: Vec<ErrorLocation>,
+
+    /// A list of path segments starting at the root of the response and ending with the field
+    /// associated with the error.
+    ///
+    /// From the [Error Result Format](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format)
+    /// subsection of the GraphQL specification:
+    ///
+    /// > If an error can be associated to a particular field in the GraphQL result, it must contain
+    /// > an entry with the key `path` that details the path of the response field which experienced
+    /// > the error. This allows clients to identify whether a `null` result is intentional or
+    /// > caused by a runtime error.
+    /// >
+    /// > This field should be a list of path segments starting at the root of the response and
+    /// > ending with the field associated with the error. Path segments that represent fields
+    /// > should be strings, and path segments that represent list indices should be 0-indexed
+    /// > integers. If the error happens in an aliased field, the path to the error should use the
+    /// > aliased name, since it represents a path in the response, not in the request.
+    #[serde(default)]
+    pub path: Vec<String>,
+}
+
+/// A location describing the beginning of the associated syntax element causing the error.
+#[derive(Debug, serde::Deserialize)]
+pub struct ErrorLocation {
+    pub line: usize,
+    pub column: usize,
+}
+
+/// A response to a GraphQL request.
+///
+/// As specified in the section [7. Response](https://spec.graphql.org/draft/#sec-Response) of the
+/// GraphQL specification.
+#[derive(Debug, serde::Deserialize)]
+pub struct ResponseBody<T> {
+    /// The e response will be the result of the execution of the requested operation.
+    ///
+    /// If the operation was a query, this output will be an object of the query root operation
+    /// type; if the operation was a mutation, this output will be an object of the mutation root
+    /// operation type.
+    ///
+    /// If an error was raised before execution begins, the data entry should not be present in the
+    /// result; If an error was raised during the execution that prevented a valid response, the
+    /// data entry in the response should be `null`. In both cases the field will be set to `None`.
+    pub data: Option<T>,
+
+    /// The errors entry in the response is a non-empty list of [`Error`] raised during the request,
+    /// where each error is a map of data described by the error result specified in the section
+    /// [7.1.2. Errors](https://spec.graphql.org/draft/#sec-Errors) of the GraphQL specification.
+    #[serde(default)]
+    pub errors: Vec<Error>,
+}

--- a/graphql-http/src/http_client.rs
+++ b/graphql-http/src/http_client.rs
@@ -1,0 +1,231 @@
+//! HTTP client extensions.
+
+#[cfg(feature = "http-reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-reqwest")))]
+pub use reqwest_ext::ReqwestExt;
+
+use crate::http::response::{Error, ResponseBody};
+
+/// The error type returned by `ReqwestExt`
+#[cfg(feature = "http-reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-reqwest")))]
+#[derive(thiserror::Error, Debug)]
+pub enum RequestError {
+    /// An error occurred while serializing the GraphQL request.
+    #[error("Error serializing GraphQL request parameters: {0}")]
+    RequestSerializationError(serde_json::Error),
+
+    /// An error occurred while making the HTTP request.
+    #[error("Error making HTTP request: {0}")]
+    RequestSendError(#[from] reqwest::Error),
+
+    /// An error occurred while receiving the HTTP response.
+    #[error("Error receiving HTTP response ({0}): {1}")]
+    ResponseRecvError(reqwest::StatusCode, String),
+
+    /// An error occurred while deserializing the GraphQL response.
+    #[error("Error deserializing GraphQL response body: {0}")]
+    ResponseDeserializationError(serde_json::Error),
+}
+
+/// The possible errors results of a GraphQL-over-HTTP response.
+#[derive(thiserror::Error, Debug)]
+pub enum ResponseError {
+    /// The GraphQL response is empty.
+    #[error("Empty response")]
+    Empty,
+
+    /// The GraphQL request failed.
+    #[error("GraphQL request failed: {errors:?}")]
+    Failure {
+        /// A list of errors returned by the server.
+        errors: Vec<Error>,
+    },
+}
+
+/// The result type of a GraphQL-over-HTTP request.
+pub type ResponseResult<ResponseData> = Result<ResponseData, ResponseError>;
+
+/// Process the GraphQL response body.
+fn process_response_body<ResponseData>(
+    resp: ResponseBody<ResponseData>,
+) -> ResponseResult<ResponseData>
+where
+    ResponseData: serde::de::DeserializeOwned,
+{
+    // [7.1.2 Errors](https://spec.graphql.org/draft/#sec-Errors)
+    //
+    // > If present, the `errors` entry in the response must contain at least one error. If no
+    // > `errors` were raised during the request, the errors entry must not be present in the
+    // > result.
+    //
+    // > If the `data` entry in the response is not present, the `errors` entry MUST be present. It
+    // > MUST contain at least one _request error_ indicating why no data was able to be returned.
+    //
+    // > If the data entry in the response is present (including if it is the value **null**), the
+    // > `errors` entry MUST be present if and only if one or more _field error_ was raised during
+    // > execution.
+    match (resp.data, resp.errors) {
+        (Some(data), errors) if errors.is_empty() => Ok(data),
+        (None, errors) if errors.is_empty() => Err(ResponseError::Empty),
+        // Do not consider partial responses
+        (_, errors) => Err(ResponseError::Failure { errors }),
+    }
+}
+
+#[cfg(feature = "http-reqwest")]
+mod reqwest_ext {
+    use async_trait::async_trait;
+    use reqwest::header::{ACCEPT, CONTENT_TYPE};
+
+    use crate::http::request::{IntoRequestParameters, GRAPHQL_REQUEST_MEDIA_TYPE};
+    use crate::http::response::{GRAPHQL_LEGACY_RESPONSE_MEDIA_TYPE, GRAPHQL_RESPONSE_MEDIA_TYPE};
+
+    use super::{process_response_body, RequestError, ResponseResult};
+
+    /// An extension trait for reqwest::RequestBuilder.
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-reqwest")))]
+    #[async_trait]
+    pub trait ReqwestExt {
+        /// Sets the `Content-Type` and `Accept` headers to the GraphQL-over-HTTP media types and
+        /// serializes the GraphQL request.
+        ///
+        /// If the GraphQL request cannot be serialized, an error is returned.
+        fn graphql(self, req: impl IntoRequestParameters) -> Result<Self, serde_json::Error>
+        where
+            Self: Sized;
+
+        /// Runs a GraphQL query with the parameters in RequestBuilder, deserializes
+        /// the and returns the result.
+        async fn send_graphql<ResponseData>(
+            self,
+            req: impl IntoRequestParameters + Send,
+        ) -> Result<ResponseResult<ResponseData>, RequestError>
+        where
+            ResponseData: serde::de::DeserializeOwned;
+    }
+
+    #[async_trait]
+    impl ReqwestExt for reqwest::RequestBuilder {
+        fn graphql(self, req: impl IntoRequestParameters) -> Result<Self, serde_json::Error>
+        where
+            Self: Sized,
+        {
+            let gql_request = req.into_request_parameters();
+            let gql_request_body = serde_json::to_vec(&gql_request)?;
+
+            let builder = self
+                // Set `Content-Type` header to `application/json` as specified in the section
+                // [5.4 POST](https://graphql.github.io/graphql-over-http/draft/#sec-POST) of the
+                // GraphQL-over-HTTP specification.
+                .header(CONTENT_TYPE, GRAPHQL_REQUEST_MEDIA_TYPE)
+                // Set `Accept` header to `application/json` and `application/graphql-response+json` to
+                // support both the legacy and the current GraphQL-over-HTTP media types. As specified in
+                // the section [5.2.1 Legacy Watershed](https://graphql.github.io/graphql-over-http/draft/#sec-Legacy-Watershed)
+                // of the GraphQL-over-HTTP specification.
+                .header(
+                    ACCEPT,
+                    format!(
+                        "{}; charset=utf-8, {}; charset=utf-8",
+                        GRAPHQL_RESPONSE_MEDIA_TYPE, GRAPHQL_LEGACY_RESPONSE_MEDIA_TYPE
+                    ),
+                )
+                .body(gql_request_body);
+
+            Ok(builder)
+        }
+
+        async fn send_graphql<ResponseData>(
+            self,
+            req: impl IntoRequestParameters + Send,
+        ) -> Result<ResponseResult<ResponseData>, RequestError>
+        where
+            ResponseData: serde::de::DeserializeOwned,
+        {
+            let builder = self
+                .graphql(req)
+                .map_err(RequestError::RequestSerializationError)?;
+
+            match builder.send().await {
+                Ok(response) => {
+                    // Process a GraphQL-over-HTTP response.
+                    if !is_legacy_response(&response) {
+                        process_graphql_response(response).await
+                    } else {
+                        process_legacy_graphql_response(response).await
+                    }
+                }
+                Err(e) => Err(RequestError::RequestSendError(e)),
+            }
+        }
+    }
+
+    /// Determine if the response is a GraphQL-over-HTTP response using the legacy media type.
+    fn is_legacy_response(response: &reqwest::Response) -> bool {
+        let content_type = response.headers().get(CONTENT_TYPE);
+        match content_type {
+            // If the `Content-Type` header is present, check if it is the legacy response media
+            // type or the current GraphQL-over-HTTP response media type.
+            Some(header) => header
+                .as_bytes()
+                .eq_ignore_ascii_case(GRAPHQL_LEGACY_RESPONSE_MEDIA_TYPE.as_bytes()),
+            // If no `Content-Type` header is present, the response SHOULD be interpreted as if the
+            // header field had the value `application/json` (legacy media type).
+            None => true,
+        }
+    }
+
+    /// Process the GraphQL-over-HTTP response when the media type, `application/graphql-response+json`,
+    /// is used.
+    ///
+    /// See the section [6.4.2 application/graphql-response+json](
+    /// https://graphql.github.io/graphql-over-http/draft/#sec-application-graphql-response-json)
+    /// of the GraphQL-over-HTTP specification for more information.
+    async fn process_graphql_response<ResponseData>(
+        resp: reqwest::Response,
+    ) -> Result<ResponseResult<ResponseData>, RequestError>
+    where
+        ResponseData: serde::de::DeserializeOwned,
+    {
+        // TODO: Add support for the GraphQL-over-HTTP response media type (non-legacy)
+        //  Fall back to legacy media type for now.
+        process_legacy_graphql_response(resp).await
+    }
+
+    /// Process the GraphQL-over-HTTP response when the legacy media type, `application/json`, is used.
+    ///
+    /// See the section [6.4.1 application/json](https://graphql.github.io/graphql-over-http/draft/#sec-application-json)
+    /// of the GraphQL-over-HTTP specification for more information.
+    async fn process_legacy_graphql_response<ResponseData>(
+        resp: reqwest::Response,
+    ) -> Result<ResponseResult<ResponseData>, RequestError>
+    where
+        ResponseData: serde::de::DeserializeOwned,
+    {
+        let status = resp.status();
+
+        // [6.4.1 application/json](https://graphql.github.io/graphql-over-http/draft/#sec-application-json)
+        //
+        // > The server SHOULD use the 200 status code for every response to a well-formed
+        // > GraphQL-over-HTTP request, independent of any GraphQL request error or GraphQL field error
+        // > raised.
+        //
+        // > For compatibility with legacy servers, this specification allows the use of `4xx` or `5xx`
+        // > status codes for a failed well-formed GraphQL-over-HTTP request where the response uses
+        // > the `application/json` media type, but it is **strongly discouraged**.
+        if !status.is_success() && !status.is_client_error() && !status.is_server_error() {
+            return Err(RequestError::ResponseRecvError(status, resp.text().await?));
+        }
+
+        // Receive the response body.
+        let response = resp.bytes().await.map_err(|err| {
+            RequestError::ResponseRecvError(status, format!("Error reading response body: {}", err))
+        })?;
+
+        // Deserialize the response body.
+        let response = serde_json::from_slice(&response)
+            .map_err(RequestError::ResponseDeserializationError)?;
+
+        Ok(process_response_body(response))
+    }
+}

--- a/graphql-http/src/lib.rs
+++ b/graphql-http/src/lib.rs
@@ -1,0 +1,4 @@
+mod compat;
+pub mod graphql;
+pub mod http;
+pub mod http_client;

--- a/graphql-http/tests/assets/queries.graphql
+++ b/graphql-http/tests/assets/queries.graphql
@@ -1,0 +1,17 @@
+query AllFilms {
+    allFilms {
+        films {
+            title
+            director
+            releaseDate
+        }
+    }
+}
+
+query FilmByFilmId($id: ID!) {
+    film(filmID: $id) {
+        title
+        director
+        releaseDate
+    }
+}

--- a/graphql-http/tests/assets/schema.graphql
+++ b/graphql-http/tests/assets/schema.graphql
@@ -1,0 +1,1166 @@
+schema {
+  query: Root
+}
+
+"""A single film."""
+type Film implements Node {
+  """The title of this film."""
+  title: String
+
+  """The episode number of this film."""
+  episodeID: Int
+
+  """The opening paragraphs at the beginning of this film."""
+  openingCrawl: String
+
+  """The name of the director of this film."""
+  director: String
+
+  """The name(s) of the producer(s) of this film."""
+  producers: [String]
+
+  """The ISO 8601 date format of film release at original creator country."""
+  releaseDate: String
+  speciesConnection(after: String, first: Int, before: String, last: Int): FilmSpeciesConnection
+  starshipConnection(after: String, first: Int, before: String, last: Int): FilmStarshipsConnection
+  vehicleConnection(after: String, first: Int, before: String, last: Int): FilmVehiclesConnection
+  characterConnection(after: String, first: Int, before: String, last: Int): FilmCharactersConnection
+  planetConnection(after: String, first: Int, before: String, last: Int): FilmPlanetsConnection
+
+  """The ISO 8601 date format of the time that this resource was created."""
+  created: String
+
+  """The ISO 8601 date format of the time that this resource was edited."""
+  edited: String
+
+  """The ID of an object"""
+  id: ID!
+}
+
+"""A connection to a list of items."""
+type FilmCharactersConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [FilmCharactersEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  characters: [Person]
+}
+
+"""An edge in a connection."""
+type FilmCharactersEdge {
+  """The item at the end of the edge"""
+  node: Person
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type FilmPlanetsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [FilmPlanetsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  planets: [Planet]
+}
+
+"""An edge in a connection."""
+type FilmPlanetsEdge {
+  """The item at the end of the edge"""
+  node: Planet
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type FilmsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [FilmsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""An edge in a connection."""
+type FilmsEdge {
+  """The item at the end of the edge"""
+  node: Film
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type FilmSpeciesConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [FilmSpeciesEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  species: [Species]
+}
+
+"""An edge in a connection."""
+type FilmSpeciesEdge {
+  """The item at the end of the edge"""
+  node: Species
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type FilmStarshipsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [FilmStarshipsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  starships: [Starship]
+}
+
+"""An edge in a connection."""
+type FilmStarshipsEdge {
+  """The item at the end of the edge"""
+  node: Starship
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type FilmVehiclesConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [FilmVehiclesEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  vehicles: [Vehicle]
+}
+
+"""An edge in a connection."""
+type FilmVehiclesEdge {
+  """The item at the end of the edge"""
+  node: Vehicle
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""An object with an ID"""
+interface Node {
+  """The id of the object."""
+  id: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+"""A connection to a list of items."""
+type PeopleConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PeopleEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  people: [Person]
+}
+
+"""An edge in a connection."""
+type PeopleEdge {
+  """The item at the end of the edge"""
+  node: Person
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""An individual person or character within the Star Wars universe."""
+type Person implements Node {
+  """The name of this person."""
+  name: String
+
+  """
+  The birth year of the person, using the in-universe standard of BBY or ABY -
+  Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
+  a battle that occurs at the end of Star Wars episode IV: A New Hope.
+  """
+  birthYear: String
+
+  """
+  The eye color of this person. Will be "unknown" if not known or "n/a" if the
+  person does not have an eye.
+  """
+  eyeColor: String
+
+  """
+  The gender of this person. Either "Male", "Female" or "unknown",
+  "n/a" if the person does not have a gender.
+  """
+  gender: String
+
+  """
+  The hair color of this person. Will be "unknown" if not known or "n/a" if the
+  person does not have hair.
+  """
+  hairColor: String
+
+  """The height of the person in centimeters."""
+  height: Int
+
+  """The mass of the person in kilograms."""
+  mass: Float
+
+  """The skin color of this person."""
+  skinColor: String
+
+  """A planet that this person was born on or inhabits."""
+  homeworld: Planet
+  filmConnection(after: String, first: Int, before: String, last: Int): PersonFilmsConnection
+
+  """The species that this person belongs to, or null if unknown."""
+  species: Species
+  starshipConnection(after: String, first: Int, before: String, last: Int): PersonStarshipsConnection
+  vehicleConnection(after: String, first: Int, before: String, last: Int): PersonVehiclesConnection
+
+  """The ISO 8601 date format of the time that this resource was created."""
+  created: String
+
+  """The ISO 8601 date format of the time that this resource was edited."""
+  edited: String
+
+  """The ID of an object"""
+  id: ID!
+}
+
+"""A connection to a list of items."""
+type PersonFilmsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PersonFilmsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""An edge in a connection."""
+type PersonFilmsEdge {
+  """The item at the end of the edge"""
+  node: Film
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type PersonStarshipsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PersonStarshipsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  starships: [Starship]
+}
+
+"""An edge in a connection."""
+type PersonStarshipsEdge {
+  """The item at the end of the edge"""
+  node: Starship
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type PersonVehiclesConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PersonVehiclesEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  vehicles: [Vehicle]
+}
+
+"""An edge in a connection."""
+type PersonVehiclesEdge {
+  """The item at the end of the edge"""
+  node: Vehicle
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""
+A large mass, planet or planetoid in the Star Wars Universe, at the time of
+0 ABY.
+"""
+type Planet implements Node {
+  """The name of this planet."""
+  name: String
+
+  """The diameter of this planet in kilometers."""
+  diameter: Int
+
+  """
+  The number of standard hours it takes for this planet to complete a single
+  rotation on its axis.
+  """
+  rotationPeriod: Int
+
+  """
+  The number of standard days it takes for this planet to complete a single orbit
+  of its local star.
+  """
+  orbitalPeriod: Int
+
+  """
+  A number denoting the gravity of this planet, where "1" is normal or 1 standard
+  G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
+  """
+  gravity: String
+
+  """The average population of sentient beings inhabiting this planet."""
+  population: Float
+
+  """The climates of this planet."""
+  climates: [String]
+
+  """The terrains of this planet."""
+  terrains: [String]
+
+  """
+  The percentage of the planet surface that is naturally occurring water or bodies
+  of water.
+  """
+  surfaceWater: Float
+  residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
+  filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
+
+  """The ISO 8601 date format of the time that this resource was created."""
+  created: String
+
+  """The ISO 8601 date format of the time that this resource was edited."""
+  edited: String
+
+  """The ID of an object"""
+  id: ID!
+}
+
+"""A connection to a list of items."""
+type PlanetFilmsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PlanetFilmsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""An edge in a connection."""
+type PlanetFilmsEdge {
+  """The item at the end of the edge"""
+  node: Film
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type PlanetResidentsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PlanetResidentsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  residents: [Person]
+}
+
+"""An edge in a connection."""
+type PlanetResidentsEdge {
+  """The item at the end of the edge"""
+  node: Person
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type PlanetsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [PlanetsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  planets: [Planet]
+}
+
+"""An edge in a connection."""
+type PlanetsEdge {
+  """The item at the end of the edge"""
+  node: Planet
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type Root {
+  allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
+  film(id: ID, filmID: ID): Film
+  allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection
+  person(id: ID, personID: ID): Person
+  allPlanets(after: String, first: Int, before: String, last: Int): PlanetsConnection
+  planet(id: ID, planetID: ID): Planet
+  allSpecies(after: String, first: Int, before: String, last: Int): SpeciesConnection
+  species(id: ID, speciesID: ID): Species
+  allStarships(after: String, first: Int, before: String, last: Int): StarshipsConnection
+  starship(id: ID, starshipID: ID): Starship
+  allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
+  vehicle(id: ID, vehicleID: ID): Vehicle
+
+  """Fetches an object given its ID"""
+  node(
+    """The ID of an object"""
+    id: ID!
+  ): Node
+}
+
+"""A type of person or character within the Star Wars Universe."""
+type Species implements Node {
+  """The name of this species."""
+  name: String
+
+  """The classification of this species, such as "mammal" or "reptile"."""
+  classification: String
+
+  """The designation of this species, such as "sentient"."""
+  designation: String
+
+  """The average height of this species in centimeters."""
+  averageHeight: Float
+
+  """The average lifespan of this species in years, null if unknown."""
+  averageLifespan: Int
+
+  """
+  Common eye colors for this species, null if this species does not typically
+  have eyes.
+  """
+  eyeColors: [String]
+
+  """
+  Common hair colors for this species, null if this species does not typically
+  have hair.
+  """
+  hairColors: [String]
+
+  """
+  Common skin colors for this species, null if this species does not typically
+  have skin.
+  """
+  skinColors: [String]
+
+  """The language commonly spoken by this species."""
+  language: String
+
+  """A planet that this species originates from."""
+  homeworld: Planet
+  personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
+  filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
+
+  """The ISO 8601 date format of the time that this resource was created."""
+  created: String
+
+  """The ISO 8601 date format of the time that this resource was edited."""
+  edited: String
+
+  """The ID of an object"""
+  id: ID!
+}
+
+"""A connection to a list of items."""
+type SpeciesConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [SpeciesEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  species: [Species]
+}
+
+"""An edge in a connection."""
+type SpeciesEdge {
+  """The item at the end of the edge"""
+  node: Species
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type SpeciesFilmsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [SpeciesFilmsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""An edge in a connection."""
+type SpeciesFilmsEdge {
+  """The item at the end of the edge"""
+  node: Film
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type SpeciesPeopleConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [SpeciesPeopleEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  people: [Person]
+}
+
+"""An edge in a connection."""
+type SpeciesPeopleEdge {
+  """The item at the end of the edge"""
+  node: Person
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A single transport craft that has hyperdrive capability."""
+type Starship implements Node {
+  """The name of this starship. The common name, such as "Death Star"."""
+  name: String
+
+  """
+  The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+  Orbital Battle Station".
+  """
+  model: String
+
+  """
+  The class of this starship, such as "Starfighter" or "Deep Space Mobile
+  Battlestation"
+  """
+  starshipClass: String
+
+  """The manufacturers of this starship."""
+  manufacturers: [String]
+
+  """The cost of this starship new, in galactic credits."""
+  costInCredits: Float
+
+  """The length of this starship in meters."""
+  length: Float
+
+  """The number of personnel needed to run or pilot this starship."""
+  crew: String
+
+  """The number of non-essential people this starship can transport."""
+  passengers: String
+
+  """
+  The maximum speed of this starship in atmosphere. null if this starship is
+  incapable of atmosphering flight.
+  """
+  maxAtmospheringSpeed: Int
+
+  """The class of this starships hyperdrive."""
+  hyperdriveRating: Float
+
+  """
+  The Maximum number of Megalights this starship can travel in a standard hour.
+  A "Megalight" is a standard unit of distance and has never been defined before
+  within the Star Wars universe. This figure is only really useful for measuring
+  the difference in speed of starships. We can assume it is similar to AU, the
+  distance between our Sun (Sol) and Earth.
+  """
+  MGLT: Int
+
+  """The maximum number of kilograms that this starship can transport."""
+  cargoCapacity: Float
+
+  """
+  The maximum length of time that this starship can provide consumables for its
+  entire crew without having to resupply.
+  """
+  consumables: String
+  pilotConnection(after: String, first: Int, before: String, last: Int): StarshipPilotsConnection
+  filmConnection(after: String, first: Int, before: String, last: Int): StarshipFilmsConnection
+
+  """The ISO 8601 date format of the time that this resource was created."""
+  created: String
+
+  """The ISO 8601 date format of the time that this resource was edited."""
+  edited: String
+
+  """The ID of an object"""
+  id: ID!
+}
+
+"""A connection to a list of items."""
+type StarshipFilmsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [StarshipFilmsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""An edge in a connection."""
+type StarshipFilmsEdge {
+  """The item at the end of the edge"""
+  node: Film
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type StarshipPilotsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [StarshipPilotsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  pilots: [Person]
+}
+
+"""An edge in a connection."""
+type StarshipPilotsEdge {
+  """The item at the end of the edge"""
+  node: Person
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type StarshipsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [StarshipsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  starships: [Starship]
+}
+
+"""An edge in a connection."""
+type StarshipsEdge {
+  """The item at the end of the edge"""
+  node: Starship
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A single transport craft that does not have hyperdrive capability"""
+type Vehicle implements Node {
+  """
+  The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+  bike".
+  """
+  name: String
+
+  """
+  The model or official name of this vehicle. Such as "All-Terrain Attack
+  Transport".
+  """
+  model: String
+
+  """The class of this vehicle, such as "Wheeled" or "Repulsorcraft"."""
+  vehicleClass: String
+
+  """The manufacturers of this vehicle."""
+  manufacturers: [String]
+
+  """The cost of this vehicle new, in Galactic Credits."""
+  costInCredits: Float
+
+  """The length of this vehicle in meters."""
+  length: Float
+
+  """The number of personnel needed to run or pilot this vehicle."""
+  crew: String
+
+  """The number of non-essential people this vehicle can transport."""
+  passengers: String
+
+  """The maximum speed of this vehicle in atmosphere."""
+  maxAtmospheringSpeed: Int
+
+  """The maximum number of kilograms that this vehicle can transport."""
+  cargoCapacity: Float
+
+  """
+  The maximum length of time that this vehicle can provide consumables for its
+  entire crew without having to resupply.
+  """
+  consumables: String
+  pilotConnection(after: String, first: Int, before: String, last: Int): VehiclePilotsConnection
+  filmConnection(after: String, first: Int, before: String, last: Int): VehicleFilmsConnection
+
+  """The ISO 8601 date format of the time that this resource was created."""
+  created: String
+
+  """The ISO 8601 date format of the time that this resource was edited."""
+  edited: String
+
+  """The ID of an object"""
+  id: ID!
+}
+
+"""A connection to a list of items."""
+type VehicleFilmsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [VehicleFilmsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""An edge in a connection."""
+type VehicleFilmsEdge {
+  """The item at the end of the edge"""
+  node: Film
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type VehiclePilotsConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [VehiclePilotsEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  pilots: [Person]
+}
+
+"""An edge in a connection."""
+type VehiclePilotsEdge {
+  """The item at the end of the edge"""
+  node: Person
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""A connection to a list of items."""
+type VehiclesConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [VehiclesEdge]
+
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  vehicles: [Vehicle]
+}
+
+"""An edge in a connection."""
+type VehiclesEdge {
+  """The item at the end of the edge"""
+  node: Vehicle
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}

--- a/graphql-http/tests/it_graphql_http_client.rs
+++ b/graphql-http/tests/it_graphql_http_client.rs
@@ -1,0 +1,385 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use reqwest::Url;
+
+use graphql_http::graphql::IntoDocument;
+use graphql_http::http::request::{IntoRequestParameters, RequestParameters};
+use graphql_http::http_client::{ReqwestExt, ResponseError};
+
+/// The URL of the test server.
+///
+/// This a GraphQL server that implements the [Star Wars API](https://swapi.dev/). See
+/// https://github.com/graphql/swapi-graphql for more information.
+const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
+
+#[tokio::test]
+async fn send_valid_graphql_request_no_variables() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL query (string slice)
+    let query = indoc::indoc! {
+        r#"{
+            allFilms {
+                films {
+                    title
+                    director
+                    releaseDate
+                }
+            }
+        }"#
+    };
+
+    // Response types
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponse {
+        all_films: AllFilms,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct AllFilms {
+        films: Vec<Film>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Film {
+        title: String,
+        director: String,
+        release_date: String,
+    }
+
+    //// When
+    let req_fut = client.post(server_url).send_graphql::<QueryResponse>(query);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Ok(QueryResponse { all_films: AllFilms { films } }) => {
+        assert_eq!(films.len(), 6);
+
+        assert_matches!(films.iter().find(|film| film.title == "A New Hope"), Some(film) => {
+            assert_eq!(film.title, "A New Hope");
+            assert_eq!(film.director, "George Lucas");
+            assert_eq!(film.release_date, "1977-05-25");
+        });
+        assert_matches!(films.iter().find(|film| film.title == "The Empire Strikes Back"), Some(film) => {
+            assert_eq!(film.title, "The Empire Strikes Back");
+            assert_eq!(film.director, "Irvin Kershner");
+            assert_eq!(film.release_date, "1980-05-17");
+        });
+        assert_matches!(films.iter().find(|film| film.title == "Return of the Jedi"), Some(film) => {
+            assert_eq!(film.title, "Return of the Jedi");
+            assert_eq!(film.director, "Richard Marquand");
+            assert_eq!(film.release_date, "1983-05-25");
+        });
+    });
+}
+
+#[tokio::test]
+async fn send_valid_graphql_request_with_variables() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL request
+    #[derive(Debug)]
+    struct FilmRequest {
+        id: String,
+    }
+
+    impl FilmRequest {
+        fn new(id: u64) -> Self {
+            Self { id: id.to_string() }
+        }
+    }
+
+    impl IntoRequestParameters for FilmRequest {
+        fn into_request_parameters(self) -> RequestParameters {
+            // GraphQL query (string slice)
+            let query = indoc::indoc! {
+                r#"query filmByFilmId($id: ID!) {
+                    film(filmID: $id) {
+                        title
+                        director
+                        releaseDate
+                    }
+                }"#
+            };
+
+            RequestParameters {
+                query: query.into_document(),
+                operation_name: None,
+                variables: serde_json::Map::from_iter([("id".to_string(), self.id.into())]),
+                extensions: Default::default(),
+            }
+        }
+    }
+
+    // Response types
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponse {
+        film: Film,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Film {
+        title: String,
+        director: String,
+        release_date: String,
+    }
+
+    //// When
+    let req_fut = client
+        .post(server_url)
+        .send_graphql::<QueryResponse>(FilmRequest::new(1));
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Ok(QueryResponse { film }) => {
+        assert_eq!(film.title, "A New Hope");
+        assert_eq!(film.director, "George Lucas");
+        assert_eq!(film.release_date, "1977-05-25");
+    });
+}
+
+// https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Document-parsing-failure
+#[tokio::test]
+async fn send_invalid_request_document_parsing_failure() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL query (string slice)
+    let query = "{";
+
+    // Response types (dummy)
+    #[derive(Debug, serde::Deserialize)]
+    struct QueryResponse {}
+
+    //// When
+    let req_fut = client.post(server_url).send_graphql::<QueryResponse>(query);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Err(err) => {
+        assert!(err.to_string().contains("Syntax Error"));
+    });
+}
+
+// https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Field-errors-encountered-during-execution
+#[tokio::test]
+async fn send_invalid_request_field_errors_encountered_during_execution_failure() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL query (string slice)
+    let query = indoc::indoc! {
+        r#"{
+            allFilms {
+                films {
+                    title
+                    director
+                    releaseDate
+                    invalidField
+                }
+            }
+        }"#
+    };
+
+    // Response types (dummy)
+    #[derive(Debug, serde::Deserialize)]
+    struct QueryResponse {}
+
+    //// When
+    let req_fut = client.post(server_url).send_graphql::<QueryResponse>(query);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Err(ResponseError::Failure { errors }) => {
+        assert_eq!(errors.len(), 1);
+
+        assert!(errors[0].message.contains(r#"Cannot query field "invalidField" on type "Film""#));
+    });
+}
+
+// https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Operation-cannot-be-determined
+#[tokio::test]
+async fn send_invalid_request_operation_cannot_be_determined_failure_null_operation_name() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL query (string slice)
+    // Scenario: The operation name is null, but the document contains multiple operations.
+    let query = indoc::indoc! {
+        r#"
+            query filmsWithDirector {
+                allFilms {
+                    films {
+                        title
+                        director
+                    }
+                }
+            }
+            
+            query filsmWithReleaseDate {
+                allFilms {
+                    films {
+                        title
+                        releaseDate
+                    }
+                }
+            }
+        "#
+    };
+
+    let request_params = RequestParameters {
+        query: query.into_document(),
+        operation_name: None, // Null operation name
+        variables: Default::default(),
+        extensions: Default::default(),
+    };
+
+    // Response types (dummy)
+    #[derive(Debug, serde::Deserialize)]
+    struct QueryResponse {}
+
+    //// When
+    let req_fut = client
+        .post(server_url)
+        .send_graphql::<QueryResponse>(request_params);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Err(err) => {
+        assert!(err.to_string().contains(r#"Must provide operation name if query contains multiple operations"#));
+    });
+}
+
+// https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Operation-cannot-be-determined
+#[tokio::test]
+async fn send_invalid_request_operation_cannot_be_determined_failure_invalid_operation_name() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL query (string slice)
+    // Scenario: The operation name is not found in the document.
+    let query = indoc::indoc! {
+        r#"
+            query filmsWithDirector {
+                allFilms {
+                    films {
+                        title
+                        director
+                    }
+                }
+            }
+            
+            query filsmWithReleaseDate {
+                allFilms {
+                    films {
+                        title
+                        releaseDate
+                    }
+                }
+            }
+        "#
+    };
+
+    let request_params = RequestParameters {
+        query: query.into_document(),
+        operation_name: Some("invalidOperationName".to_string()), // Invalid operation name
+        variables: Default::default(),
+        extensions: Default::default(),
+    };
+
+    // Response types (dummy)
+    #[derive(Debug, serde::Deserialize)]
+    struct QueryResponse {}
+
+    //// When
+    let req_fut = client
+        .post(server_url)
+        .send_graphql::<QueryResponse>(request_params);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    println!("{:?}", response);
+    assert_matches!(response, Err(ResponseError::Failure { errors }) => {
+        assert_eq!(errors.len(), 1);
+
+        assert!(errors[0].message.contains(r#"Unknown operation named "invalidOperationName""#));
+    });
+}
+
+// https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Variable-coercion-failure
+#[tokio::test]
+async fn send_invalid_request_variable_coercion_failure() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL request
+    // GraphQL query (string slice)
+    let query = indoc::indoc! {
+        r#"query filmByFilmId($id: ID!) {
+            film(filmID: $id) {
+                title
+                director
+                releaseDate
+            }
+        }"#
+    };
+
+    let request_params = RequestParameters {
+        query: query.into_document(),
+        operation_name: None,
+        variables: serde_json::Map::from_iter([("id".to_string(), serde_json::Value::Null)]),
+        extensions: Default::default(),
+    };
+
+    // Response types (dummy)
+    #[derive(Debug, serde::Deserialize)]
+    struct QueryResponse {}
+
+    //// When
+    let req_fut = client
+        .post(server_url)
+        .send_graphql::<QueryResponse>(request_params);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Err(ResponseError::Failure { errors }) => {
+        assert_eq!(errors.len(), 1);
+
+        assert!(errors[0].message.contains(r#"Variable "$id" of non-null type "ID!" must not be null"#));
+    });
+}

--- a/graphql-http/tests/it_graphql_http_client_graphql_client.rs
+++ b/graphql-http/tests/it_graphql_http_client_graphql_client.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use graphql_client::GraphQLQuery;
+use reqwest::Url;
+
+use graphql_http::http_client::ReqwestExt;
+
+/// The URL of the test server.
+///
+/// This a GraphQL server that implements the [Star Wars API](https://swapi.dev/). See
+/// https://github.com/graphql/swapi-graphql for more information.
+const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
+
+// As `graphql_client` generates code that specifies the query, variables and response types, we
+// need to cage them under a module to avoid name collisions.
+mod test_queries {
+    #[derive(graphql_client::GraphQLQuery)]
+    #[graphql(
+        schema_path = "tests/assets/schema.graphql",
+        query_path = "tests/assets/queries.graphql"
+    )]
+    pub struct AllFilms;
+
+    #[derive(graphql_client::GraphQLQuery)]
+    #[graphql(
+        schema_path = "tests/assets/schema.graphql",
+        query_path = "tests/assets/queries.graphql"
+    )]
+    pub struct FilmByFilmId;
+}
+
+#[tokio::test]
+async fn send_valid_graphql_request_no_variables() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // Request types
+    // > Here we use `graphql_client::GraphQLQuery` derive macro to generate the GraphQL query
+    // > types. See the `test_queries` module above for the request types code.
+    // >
+    // > Note that when calling `GraphQLQuery::build_query` on a query type, the `operationName`
+    // > field is set automatically to the name of the query. This is important as the GraphQL
+    // > server will use this field to determine which query to execute, since the `query` field
+    // > will contain the full query document, i.e., the content of the file pointed by the
+    // derive macro's `query_path` argument.
+
+    // Response types
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponse {
+        all_films: QueryResponseAllFilms,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct QueryResponseAllFilms {
+        films: Vec<QueryResponseFilm>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponseFilm {
+        title: String,
+        director: String,
+        release_date: String,
+    }
+
+    //// When
+    // Build the GraphQL query
+    let query = test_queries::AllFilms::build_query(test_queries::all_films::Variables {});
+
+    let req_fut = client.post(server_url).send_graphql::<QueryResponse>(query);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Ok(QueryResponse { all_films: QueryResponseAllFilms { films } }) => {
+        assert_eq!(films.len(), 6);
+
+        assert_matches!(films.iter().find(|film| film.title == "A New Hope"), Some(film) => {
+            assert_eq!(film.title, "A New Hope");
+            assert_eq!(film.director, "George Lucas");
+            assert_eq!(film.release_date, "1977-05-25");
+        });
+        assert_matches!(films.iter().find(|film| film.title == "The Empire Strikes Back"), Some(film) => {
+            assert_eq!(film.title, "The Empire Strikes Back");
+            assert_eq!(film.director, "Irvin Kershner");
+            assert_eq!(film.release_date, "1980-05-17");
+        });
+        assert_matches!(films.iter().find(|film| film.title == "Return of the Jedi"), Some(film) => {
+            assert_eq!(film.title, "Return of the Jedi");
+            assert_eq!(film.director, "Richard Marquand");
+            assert_eq!(film.release_date, "1983-05-25");
+        });
+    });
+}
+
+#[tokio::test]
+async fn send_valid_graphql_request_with_variables() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // Request types
+    // > Here we use `graphql_client::GraphQLQuery` derive macro to generate the GraphQL query
+    // > types. See the `test_queries` module above for the request types code.
+    // >
+    // > Note that when calling `GraphQLQuery::build_query` on a query type, the `operationName`
+    // > field is set automatically to the name of the query. This is important as the GraphQL
+    // > server will use this field to determine which query to execute, since the `query` field
+    // > will contain the full query document, i.e., the content of the file pointed by the
+    // derive macro's `query_path` argument.
+
+    // Response types
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponse {
+        film: Film,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Film {
+        title: String,
+        director: String,
+        release_date: String,
+    }
+
+    //// When
+    // Build the GraphQL query
+    let request =
+        test_queries::FilmByFilmId::build_query(test_queries::film_by_film_id::Variables {
+            id: "1".to_string(),
+        });
+
+    let req_fut = client
+        .post(server_url)
+        .send_graphql::<QueryResponse>(request);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Ok(QueryResponse { film }) => {
+        assert_eq!(film.title, "A New Hope");
+        assert_eq!(film.director, "George Lucas");
+        assert_eq!(film.release_date, "1977-05-25");
+    });
+}

--- a/graphql-http/tests/it_graphql_http_client_graphql_parser.rs
+++ b/graphql-http/tests/it_graphql_http_client_graphql_parser.rs
@@ -1,0 +1,156 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use reqwest::Url;
+
+use graphql_http::graphql::IntoDocument;
+use graphql_http::http::request::{IntoRequestParameters, RequestParameters};
+use graphql_http::http_client::ReqwestExt;
+
+/// The URL of the test server.
+///
+/// This a GraphQL server that implements the [Star Wars API](https://swapi.dev/). See
+/// https://github.com/graphql/swapi-graphql for more information.
+const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
+
+#[tokio::test]
+async fn send_valid_graphql_request_no_variables() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL query (graphql_parser::query::Document)
+    let query = graphql_parser::parse_query::<&str>(indoc::indoc! {
+        r#"{
+            allFilms {
+                films {
+                    title
+                    director
+                    releaseDate
+                }
+            }
+        }"#
+    })
+    .expect("Invalid GraphQL query");
+
+    // Response types
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponse {
+        all_films: AllFilms,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct AllFilms {
+        films: Vec<Film>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Film {
+        title: String,
+        director: String,
+        release_date: String,
+    }
+
+    //// When
+    let req_fut = client.post(server_url).send_graphql::<QueryResponse>(query);
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Ok(QueryResponse { all_films: AllFilms { films } }) => {
+        assert_eq!(films.len(), 6);
+
+        assert_matches!(films.iter().find(|film| film.title == "A New Hope"), Some(film) => {
+            assert_eq!(film.title, "A New Hope");
+            assert_eq!(film.director, "George Lucas");
+            assert_eq!(film.release_date, "1977-05-25");
+        });
+        assert_matches!(films.iter().find(|film| film.title == "The Empire Strikes Back"), Some(film) => {
+            assert_eq!(film.title, "The Empire Strikes Back");
+            assert_eq!(film.director, "Irvin Kershner");
+            assert_eq!(film.release_date, "1980-05-17");
+        });
+        assert_matches!(films.iter().find(|film| film.title == "Return of the Jedi"), Some(film) => {
+            assert_eq!(film.title, "Return of the Jedi");
+            assert_eq!(film.director, "Richard Marquand");
+            assert_eq!(film.release_date, "1983-05-25");
+        });
+    });
+}
+
+#[tokio::test]
+async fn send_valid_graphql_request_with_variables() {
+    //// Given
+    let client = reqwest::Client::new();
+    let server_url: Url = TEST_SERVER_URL.parse().unwrap();
+
+    // GraphQL request
+    #[derive(Debug)]
+    struct FilmRequest {
+        id: String,
+    }
+
+    impl FilmRequest {
+        fn new(id: u64) -> Self {
+            Self { id: id.to_string() }
+        }
+    }
+
+    impl IntoRequestParameters for FilmRequest {
+        fn into_request_parameters(self) -> RequestParameters {
+            // GraphQL query (string slice)
+            let query = graphql_parser::parse_query::<&str>(indoc::indoc! {
+                r#"query filmByFilmId($id: ID!) {
+                    film(filmID: $id) {
+                        title
+                        director
+                        releaseDate
+                    }
+                }"#
+            })
+            .expect("Invalid GraphQL query");
+
+            RequestParameters {
+                query: query.into_document(),
+                operation_name: None,
+                variables: serde_json::Map::from_iter([("id".to_string(), self.id.into())]),
+                extensions: Default::default(),
+            }
+        }
+    }
+
+    // Response types
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryResponse {
+        film: Film,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Film {
+        title: String,
+        director: String,
+        release_date: String,
+    }
+
+    //// When
+    let req_fut = client
+        .post(server_url)
+        .send_graphql::<QueryResponse>(FilmRequest::new(1));
+    let response = tokio::time::timeout(Duration::from_secs(30), req_fut)
+        .await
+        .expect("Request timed out")
+        .expect("Request failed");
+
+    //// Then
+    assert_matches!(response, Ok(QueryResponse { film }) => {
+        assert_eq!(film.title, "A New Hope");
+        assert_eq!(film.director, "George Lucas");
+        assert_eq!(film.release_date, "1977-05-25");
+    });
+}


### PR DESCRIPTION
It is well-known that we have multiple handwritten re-implementations of a _reqwest_ based GraphQL-over-HTTP client. Additionally, most existing crates add an undesired overhead (e.g., schema file-based code generation).

This PR introduces a minor, GraphQL-over-HTTP spec-compliant, _reqwest_ extension trait.