### PR TITLE
chore(toolshed): set crate msrv to 1.65.0

### DIFF
--- a/toolshed/Cargo.toml
+++ b/toolshed/Cargo.toml
@@ -3,6 +3,7 @@ name = "toolshed"
 description = "A collection of Rust modules that are shared between The Graph's network services"
 version = "0.2.2"
 edition = "2021"
+rust-version = "1.65.0"
 
 
 [features]


### PR DESCRIPTION
Set `toolshed` crate's MSRV (Minimum Supported Rust Version) to 1.65.0 after determining it using [the `cargo-msrv` command](https://github.com/foresterre/cargo-msrv):

```
$ cargo msrv
...

Check for toolchain '1.63.0-x86_64-unknown-linux-gnu' failed with:
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Updating crates.io index                                                                                                                                                          │
│  Downloading crates ...                                                                                                                                                           │
│   Downloaded time-core v0.1.2                                                                                                                                                     │
│   Downloaded semver v1.0.19                                                                                                                                                       │
│   Downloaded time-macros v0.2.15                                                                                                                                                  │
│   Downloaded fastrand v2.0.1                                                                                                                                                      │
│   Downloaded time v0.3.29                                                                                                                                                         │
│   Downloaded alloy-rlp v0.3.3                                                                                                                                                     │
│ error: package `serde_with v3.3.0` cannot be built because it requires rustc 1.64 or newer, while the currently active rustc version is 1.63.0                                    │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
Check for toolchain '1.68.2-x86_64-unknown-linux-gnu' succeeded
Check for toolchain '1.65.0-x86_64-unknown-linux-gnu' succeeded

Check for toolchain '1.64.0-x86_64-unknown-linux-gnu' failed with:
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ error: package `ruint-macro v1.1.0` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.64.0                                   │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
   Finished The MSRV is: 1.65.0   ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 00:01:50
```
