### PR TITLE
chore(graphql): segregate graphql toolshed module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings --force-warn deprecated --force-warn dead-code"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings --force-warn deprecated --force-warn dead-code"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings --force-warn deprecated --force-warn dead-code"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
 members = [
     "toolshed",
+    "graphql",
 ]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "graphql"
+description = "A collection of GraphQL related Rust modules that are share between The Graph's network services"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.61.0"
+
+[features]
+default = ["http"]
+http = []
+
+[dependencies]
+firestorm = "0.5"
+graphql-parser = "0.4"
+serde = { version = "1.0", features = ["derive"] }

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,0 +1,7 @@
+# graphql
+
+A collection of GraphQL related Rust modules that are share between The Graph's network services.
+
+```toml
+graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "vX.Y.Z" }
+```

--- a/graphql/src/graphql.rs
+++ b/graphql/src/graphql.rs
@@ -1,0 +1,214 @@
+use std::collections::{BTreeMap, HashMap};
+use std::convert::TryInto as _;
+use std::ops::Deref;
+
+use firestorm::profile_fn;
+pub use graphql_parser;
+use graphql_parser::query as q;
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+// TODO: (Performance) may want to do zero-copy here later.
+pub type StaticValue = q::Value<'static, String>;
+
+/// Variable value for a GraphQL query.
+#[derive(Clone, Debug, Deserialize)]
+struct DeserializableGraphQlValue(#[serde(with = "GraphQLValue")] StaticValue);
+
+#[derive(Clone, Debug, Serialize)]
+struct SerializableGraphQlValue<'a>(#[serde(with = "GraphQLValue")] &'a StaticValue);
+
+fn deserialize_variables<'de, D>(deserializer: D) -> Result<HashMap<String, StaticValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    profile_fn!(deserialize_variables);
+    let pairs: BTreeMap<String, DeserializableGraphQlValue> =
+        Deserialize::deserialize(deserializer)?;
+    Ok(pairs.into_iter().map(|(k, v)| (k, v.0)).collect())
+}
+
+fn serialize_variables<S>(vars: &HashMap<String, StaticValue>, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    profile_fn!(serialize_variables);
+
+    let mut seq = ser.serialize_map(Some(vars.len()))?;
+    for (key, value) in vars.iter() {
+        seq.serialize_key(key)?;
+        seq.serialize_value(&SerializableGraphQlValue(value))?;
+    }
+    seq.end()
+}
+
+/// Variable values for a GraphQL query.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct QueryVariables(
+    #[serde(
+        deserialize_with = "deserialize_variables",
+        serialize_with = "serialize_variables"
+    )]
+    pub HashMap<String, StaticValue>,
+);
+
+impl Deref for QueryVariables {
+    type Target = HashMap<String, StaticValue>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged, remote = "StaticValue")]
+enum GraphQLValue {
+    #[serde(
+        deserialize_with = "deserialize_number",
+        serialize_with = "serialize_number"
+    )]
+    Int(q::Number),
+    Float(f64),
+    String(String),
+    Boolean(bool),
+    Null,
+    Enum(String),
+    #[serde(
+        deserialize_with = "deserialize_list",
+        serialize_with = "serialize_list"
+    )]
+    List(Vec<StaticValue>),
+    #[serde(
+        deserialize_with = "deserialize_object",
+        serialize_with = "serialize_object"
+    )]
+    Object(BTreeMap<String, StaticValue>),
+    Variable(String),
+}
+
+fn deserialize_number<'de, D>(deserializer: D) -> Result<q::Number, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let i: i32 = Deserialize::deserialize(deserializer)?;
+    Ok(q::Number::from(i))
+}
+
+fn serialize_number<S>(number: &q::Number, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    ser.serialize_i32(number.as_i64().unwrap().try_into().unwrap())
+}
+
+fn deserialize_list<'de, D>(deserializer: D) -> Result<Vec<StaticValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values: Vec<DeserializableGraphQlValue> = Deserialize::deserialize(deserializer)?;
+    Ok(values.into_iter().map(|v| v.0).collect())
+}
+
+fn serialize_list<S>(list: &Vec<StaticValue>, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = ser.serialize_seq(Some(list.len()))?;
+    for value in list.iter() {
+        seq.serialize_element(&SerializableGraphQlValue(value))?;
+    }
+    seq.end()
+}
+
+fn deserialize_object<'de, D>(deserializer: D) -> Result<BTreeMap<String, StaticValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let pairs: BTreeMap<String, DeserializableGraphQlValue> =
+        Deserialize::deserialize(deserializer)?;
+    Ok(pairs.into_iter().map(|(k, v)| (k, v.0)).collect())
+}
+
+fn serialize_object<S>(obj: &BTreeMap<String, StaticValue>, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = ser.serialize_map(Some(obj.len()))?;
+    for (key, value) in obj.iter() {
+        seq.serialize_key(key)?;
+        seq.serialize_value(&SerializableGraphQlValue(value))?;
+    }
+    seq.end()
+}
+
+pub trait IntoStaticValue {
+    fn to_graphql(self) -> StaticValue;
+}
+
+impl IntoStaticValue for i32 {
+    fn to_graphql(self) -> StaticValue {
+        StaticValue::Int(self.into())
+    }
+}
+
+impl IntoStaticValue for bool {
+    fn to_graphql(self) -> StaticValue {
+        StaticValue::Boolean(self)
+    }
+}
+
+impl IntoStaticValue for StaticValue {
+    fn to_graphql(self) -> StaticValue {
+        self
+    }
+}
+
+impl IntoStaticValue for String {
+    fn to_graphql(self) -> StaticValue {
+        StaticValue::String(self)
+    }
+}
+
+impl<'a, T: q::Text<'a>> IntoStaticValue for &'_ q::Value<'a, T> {
+    fn to_graphql(self) -> StaticValue {
+        match self {
+            q::Value::Boolean(b) => StaticValue::Boolean(*b),
+            q::Value::Enum(t) => StaticValue::Enum(t.as_ref().to_string()),
+            q::Value::Float(f) => StaticValue::Float(*f),
+            q::Value::Int(i) => StaticValue::Int(i.clone()),
+            q::Value::Variable(v) => StaticValue::Variable(v.as_ref().to_string()),
+            q::Value::Object(o) => StaticValue::Object(
+                o.iter()
+                    .map(|(k, v)| (k.as_ref().to_string(), v.to_graphql()))
+                    .collect(),
+            ),
+            q::Value::List(l) => {
+                StaticValue::List(l.iter().map(IntoStaticValue::to_graphql).collect())
+            }
+            q::Value::String(s) => StaticValue::String(s.to_string()),
+            q::Value::Null => StaticValue::Null,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! GraphQL parsing must not overflow the stack. These tests are added to ensure that this is
+    //! caught in graphql-parser _and_ that it is an error. We are relying on this being an error
+    //! because other GraphQL traversal code may not been secured against stack overflow.
+
+    use super::*;
+
+    #[test]
+    fn obj_recursion() {
+        let query = format!("query {}{}", "{ a ".repeat(51), "}".repeat(51));
+        let query = q::parse_query::<&str>(&query);
+        assert!(query.is_err());
+    }
+
+    #[test]
+    fn list_recursion() {
+        let query = format!("query {{ a(l: {}1{} ) }}", "[".repeat(49), "]".repeat(49));
+        let query = q::parse_query::<&str>(&query);
+        assert!(query.is_err());
+    }
+}

--- a/graphql/src/http.rs
+++ b/graphql/src/http.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Response<T> {
+    pub data: Option<T>,
+    pub errors: Option<Vec<Error>>,
+}
+
+#[derive(Deserialize)]
+pub struct Error {
+    pub message: String,
+}
+
+impl<T> Response<T> {
+    pub fn unpack(self) -> Result<T, String> {
+        self.data.ok_or_else(|| {
+            self.errors
+                .unwrap_or_default()
+                .into_iter()
+                .map(|err| err.message)
+                .collect::<Vec<String>>()
+                .join(", ")
+        })
+    }
+}

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -1,0 +1,6 @@
+pub use graphql::*;
+
+mod graphql;
+
+#[cfg(feature = "http")]
+pub mod http;

--- a/toolshed/src/lib.rs
+++ b/toolshed/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bytes;
 pub mod epoch_cache;
+#[deprecated(since = "0.2.3", note = "Use `graphql` crate instead")]
 #[cfg(feature = "graphql")]
 pub mod graphql;
 pub mod thegraph;


### PR DESCRIPTION
As discussed and agreed in a Slack discussion:

> [...]
> something as involved as a GraphQL parser probably should be it’s own crate as well.

So, in this PR:

- [x] Segregate the GraphQL module into its own crate.
- [x] Deprecate the `toolshed`'s `graphql` module in favor of the new `graphql` crate.

Additionally, these changes align with the GraphQL client work in #9.