### PR TITLE
docs(toolshed): document url wrapper type

### DIFF
--- a/toolshed/src/url.rs
+++ b/toolshed/src/url.rs
@@ -1,33 +1,34 @@
+// Re-export the `url` crate
 pub use url;
 
-use std::{fmt, ops::Deref, str::FromStr};
-
-/// A Url wrapper that is Debug formatted using Display
+/// A [`url::Url`] wrapper that is [`std::fmt::Debug`] formatted using [`std::fmt::Display`].
 #[repr(transparent)]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Url(pub url::Url);
 
-impl fmt::Debug for Url {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Debug for Url {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl fmt::Display for Url {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for Url {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl FromStr for Url {
-    type Err = <url::Url as FromStr>::Err;
+impl std::str::FromStr for Url {
+    type Err = <url::Url as std::str::FromStr>::Err;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         url::Url::from_str(s).map(Self)
     }
 }
 
-impl Deref for Url {
+impl std::ops::Deref for Url {
     type Target = url::Url;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }


### PR DESCRIPTION
Cherry-picked changes from #9. 

- [x] Document toolshed's `url` module.