### PR TITLE
feature: improve DeploymentId encoding/decoding

### DIFF
--- a/toolshed/Cargo.toml
+++ b/toolshed/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_with = "3.2.0"
 thiserror = "1.0.49"
 url = { version = "2.4.0", optional = true }
+async-graphql = "6.0.7"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/toolshed/src/thegraph/mod.rs
+++ b/toolshed/src/thegraph/mod.rs
@@ -3,6 +3,7 @@ pub mod attestation;
 use std::{fmt, fmt::LowerHex, str::FromStr};
 
 use alloy_primitives::{Address, BlockHash, BlockNumber, B256};
+use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use sha3::{
@@ -136,6 +137,22 @@ impl fmt::Debug for DeploymentId {
 impl LowerHex for DeploymentId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+#[Scalar]
+impl ScalarType for DeploymentId {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        if let Value::String(value) = &value {
+            Ok(DeploymentId::from_str(value)?)
+        } else {
+            Err(InputValueError::expected_type(value))
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        // Convert to Qm...
+        Value::String(self.to_string())
     }
 }
 


### PR DESCRIPTION
This adds support for decoding/encoding to and from hex strings in addition to IPFS hashes / CIDv0.

Introducing a dedicated `DeploymentIdError` type makes this a breaking change, but perhaps we're ok with that given the benefits.

The reason this is useful is that in various places we store deployment IDs as hex strings (e.g. in the indexer software). Instead of explicitly handling these cases on one-off basis, the changes introduced here allow to treat them all the same.