### PR TITLE
chore(ci): make renovate bot pin github actions versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,10 +3,11 @@
   extends: [
     "config:base",
     ":semanticCommits",
-    ":semanticCommitTypeAll(chore)"
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests",
   ],
   schedule: [
-    "before 6am on monday",
+    "before 6am every weekday",
   ],
   rebaseStalePrs: true,
   lockFileMaintenance: {


### PR DESCRIPTION
This PR updates Renovate bot's configuration:
- [x] Follow Github Actions [(security) best practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and configure renovate bot to pin GitHub Actions' versions.
- [x] Change the Renovate bot's schedule to run every weekday before 6AM.
