### PR TITLE
chore(toolshed): bump toolshed version v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ services.
 * **toolshed:** A collection of rust modules that are shared between The Graph's network services.
 
     ```toml
-    toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.2" }
+    toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.3" }
     ```
 * **graphql:** A collection of GraphQL related Rust modules that are share between The Graph's network services.
 

--- a/toolshed/Cargo.toml
+++ b/toolshed/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "toolshed"
 description = "A collection of Rust modules that are shared between The Graph's network services"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.65.0"
 


### PR DESCRIPTION
I am bumping the toolshed version to v0.2.3 as some dependencies have been upgraded, and other changes have occurred since the last release.