### PR TITLE
fix graphql-http feature issue and deprecate graphql crate http module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ services.
 * **graphql:** A collection of GraphQL related Rust modules that are share between The Graph's network services.
 
     ```toml
-    graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.1.0" }
+    graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.2.0" }
     ```
 * **graphql-http:** A _reqwest_ based GraphQL-over-HTTP client.
 

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ services.
 * **graphql-http:** A _reqwest_ based GraphQL-over-HTTP client.
 
     ```toml
-    graphql-http = { git = "https://github.com/eandn/toolshed", tag = "graphql-http-v0.1.0" }
+    graphql-http = { git = "https://github.com/eandn/toolshed", tag = "graphql-http-v0.1.1" }
     ```

--- a/graphql-http/Cargo.toml
+++ b/graphql-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-http"
 description = "A reqwest based GraphQL-over-HTTP client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.63.0"
 

--- a/graphql-http/Cargo.toml
+++ b/graphql-http/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 rust-version = "1.63.0"
 
 [features]
-http-reqwest = ["dep:async-trait", "dep:thiserror", "dep:reqwest"]
+http-reqwest = ["dep:async-trait", "dep:reqwest"]
 compat-graphql-client = ["dep:graphql_client"]
 compat-graphql-parser = ["dep:graphql-parser"]
 
@@ -18,7 +18,7 @@ graphql_client = { version = "0.13.0", optional = true }
 reqwest = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = { version = "1.0", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql"
 description = "A collection of GraphQL related Rust modules that are share between The Graph's network services"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.61.0"
 

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -2,5 +2,6 @@ mod graphql;
 
 pub use crate::graphql::*;
 
+#[deprecated(since = "0.2.0", note = "Please use `graphql-http` crate instead")]
 #[cfg(feature = "http")]
 pub mod http;


### PR DESCRIPTION
This PR batches the following changes:

### Ctrate `graphql-http`
- [x] Fix the issue caused by the `thiserror` optional dependency tied to the `http-reqwest` feature. It is no longer optional.
- [x] Release a v0.1.1 to version with the hotfix.

### Crate `graphql`
- [x] Deprecated the `http` module in favor of `graphql-http` crate.
- [x] Release a v0.2.0 to make the deprecation effective. It will be removed in future releases (e.g., v0.3.0)

Once these changes are merged, the `graphql-v0.2.0` and `graphql-http-v0.1.1` tags will be created.