### PR TITLE
feat(thegraph): add thegraph crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ resolver = "2"
 members = [
     "toolshed",
     "graphql",
-    "graphql-http"
+    "graphql-http",
+    "thegraph"
 ]

--- a/README.md
+++ b/README.md
@@ -5,18 +5,26 @@ services.
 
 ### Crates
 
-* **toolshed:** A collection of rust modules that are shared between The Graph's network services.
+* **thegraph:** A collection of rust modules that are shared between The Graph's network services.
 
     ```toml
-    toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.3.0" }
+    thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.1.0" }
     ```
+
 * **graphql:** A collection of GraphQL related Rust modules that are share between The Graph's network services.
 
     ```toml
     graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0" }
     ```
+
 * **graphql-http:** A _reqwest_ based GraphQL-over-HTTP client.
 
     ```toml
     graphql-http = { git = "https://github.com/eandn/toolshed", tag = "graphql-http-v0.1.1" }
+    ```
+
+* **toolshed:** A collection of rust modules that are shared between The Graph's network services.
+
+    ```toml
+    toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.3.0" }
     ```

--- a/thegraph/Cargo.toml
+++ b/thegraph/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "thegraph"
+description = "A collection of Rust modules that are shared between The Graph's network services"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.67.1"
+
+[features]
+subgraph-client = ["dep:tracing", "dep:indoc", "dep:serde_json", "toolshed/url", "dep:reqwest", "graphql-http/http-reqwest"]
+
+[dependencies]
+alloy-primitives = { version = "0.5.0", features = ["serde"] }
+alloy-sol-types = "0.5.0"
+async-graphql = "6.0.11"
+bs58 = "0.5.0"
+ethers-core = { version = "2.0.11", default-features = false }
+graphql-http = { git = "https://github.com/edgeandnode/toolshed.git", tag = "graphql-http-v0.1.1", optional = true }
+indoc = { version = "2.0.4", optional = true }
+reqwest = { version = "0.11.22", optional = true }
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = { version = "1.0.108", optional = true, features = ["raw_value"] }
+serde_with = "3.4.0"
+sha3 = "0.10.8"
+thiserror = "1.0.50"
+toolshed = { git = "https://github.com/edgeandnode/toolshed.git", tag = "v0.3.0", optional = true }
+tracing = { version = "0.1.40", optional = true }
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+test-with = { version = "0.12.1", default-features = false }
+tokio = { version = "1.34.0", features = ["macros", "rt"] }

--- a/thegraph/README.md
+++ b/thegraph/README.md
@@ -1,0 +1,7 @@
+# thegraph
+
+This crate contains a collection of Rust modules that are shared between The Graph's network services.
+
+```toml
+thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-vX.Y.Z" }
+```

--- a/thegraph/src/client.rs
+++ b/thegraph/src/client.rs
@@ -1,0 +1,4 @@
+pub use subgraph_client::*;
+
+pub mod queries;
+mod subgraph_client;

--- a/thegraph/src/client/queries.rs
+++ b/thegraph/src/client/queries.rs
@@ -1,0 +1,203 @@
+use graphql_http::http::request::IntoRequestParameters;
+use graphql_http::http_client::{ReqwestExt, ResponseResult};
+use serde::de::DeserializeOwned;
+use toolshed::url::Url;
+
+/// Send an authenticated GraphQL query to a subgraph.
+pub async fn send_query<T>(
+    client: &reqwest::Client,
+    url: Url,
+    ticket: Option<&str>,
+    query: impl IntoRequestParameters + Send,
+) -> Result<ResponseResult<T>, String>
+where
+    T: DeserializeOwned,
+{
+    let mut builder = client.post(url.0);
+
+    if let Some(ticket) = ticket {
+        builder = builder.bearer_auth(ticket)
+    }
+
+    let res = builder
+        .send_graphql(query)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    Ok(res)
+}
+
+pub async fn send_subgraph_query<T>(
+    client: &reqwest::Client,
+    subgraph_url: Url,
+    ticket: Option<&str>,
+    query: impl IntoRequestParameters + Send,
+) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    send_query(client, subgraph_url, ticket, query)
+        .await
+        .map_err(|err| format!("Error sending subgraph graphql query: {}", err))?
+        .map_err(|err| err.to_string())
+}
+
+/// Subgraphs sometimes fall behind, be it due to failing or the Graph Node may be having issues. The
+/// `_meta` field can now be added to any query so that it is possible to determine against which block
+/// the query was effectively executed.
+pub mod meta {
+    use crate::types::BlockPointer;
+    use serde::Deserialize;
+    use toolshed::url::Url;
+
+    use super::send_query;
+
+    const SUBGRAPH_META_QUERY_DOCUMENT: &str = r#"{ meta: _meta { block { number hash } } }"#;
+
+    #[derive(Debug, Deserialize)]
+    pub struct SubgraphMetaQueryResponse {
+        pub meta: Meta,
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct Meta {
+        pub block: BlockPointer,
+    }
+
+    pub async fn send_subgraph_meta_query(
+        client: &reqwest::Client,
+        subgraph_url: Url,
+        ticket: Option<&str>,
+    ) -> Result<SubgraphMetaQueryResponse, String> {
+        send_query(client, subgraph_url, ticket, SUBGRAPH_META_QUERY_DOCUMENT)
+            .await
+            .map_err(|err| format!("Error sending subgraph meta query: {}", err))?
+            .map_err(|err| err.to_string())
+    }
+}
+
+pub mod page {
+    use alloy_primitives::{BlockHash, BlockNumber};
+    use graphql_http::graphql::{Document, IntoDocument, IntoDocumentWithVariables};
+    use graphql_http::http_client::ResponseResult;
+    use serde::{Deserialize, Serialize};
+    use serde_json::value::RawValue;
+    use toolshed::url::Url;
+
+    use indoc::indoc;
+
+    use super::{meta::Meta, send_query};
+
+    /// The block at which the query should be executed.
+    ///
+    /// This is part of the input arguments of the [`SubgraphPageQuery`].
+    #[derive(Clone, Debug, Default, Serialize)]
+    pub struct BlockHeight {
+        /// Value containing a block hash
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hash: Option<BlockHash>,
+
+        /// Value containing a block number
+        #[serde(skip_serializing_if = "Option::is_none")]
+        number: Option<BlockNumber>,
+
+        /// Value containing the minimum block number.
+        ///
+        /// In the case of `number_gte`, the query will be executed on the latest block only if
+        /// the subgraph has progressed to or past the minimum block number.
+        /// Defaults to the latest block when omitted.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        number_gte: Option<BlockNumber>,
+    }
+
+    impl BlockHeight {
+        pub fn new_with_block_number_gte(number_gte: BlockNumber) -> Self {
+            Self {
+                number_gte: Some(number_gte),
+                ..Default::default()
+            }
+        }
+
+        pub fn new_with_block_hash(hash: BlockHash) -> Self {
+            Self {
+                hash: Some(hash),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    pub struct SubgraphPageQueryVars {
+        /// The block at which the query should be executed.
+        block: BlockHeight,
+        first: usize,
+        last: String,
+    }
+
+    pub struct SubgraphPageQuery {
+        query: Document,
+        vars: SubgraphPageQueryVars,
+    }
+
+    impl SubgraphPageQuery {
+        pub fn new(
+            query: impl IntoDocument,
+            block: BlockHeight,
+            first: usize,
+            last: String,
+        ) -> Self {
+            Self {
+                query: query.into_document(),
+                vars: SubgraphPageQueryVars { block, first, last },
+            }
+        }
+    }
+
+    impl IntoDocumentWithVariables for SubgraphPageQuery {
+        type Variables = SubgraphPageQueryVars;
+
+        fn into_document_with_variables(self) -> (Document, Self::Variables) {
+            let query = format!(
+                indoc! {
+                    r#"query ($block: Block_height!, $first: Int!, $last: String!) {{
+                    meta: _meta(block: $block) {{ block {{ number hash }} }}
+                    results: {query}
+                }}"#
+                },
+                query = self.query
+            );
+
+            (query.into_document(), self.vars)
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct SubgraphPageQueryResponse {
+        pub meta: Meta,
+        pub results: Vec<Box<RawValue>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct SubgraphPageQueryResponseOpaqueEntry {
+        pub id: String,
+    }
+
+    pub async fn send_subgraph_page_query(
+        client: &reqwest::Client,
+        subgraph_url: Url,
+        ticket: Option<&str>,
+        query: impl IntoDocument,
+        block_height: BlockHeight,
+        batch_size: usize,
+        last: Option<String>,
+    ) -> Result<ResponseResult<SubgraphPageQueryResponse>, String> {
+        send_query(
+            client,
+            subgraph_url,
+            ticket,
+            SubgraphPageQuery::new(query, block_height, batch_size, last.unwrap_or_default()),
+        )
+        .await
+        .map_err(|err| format!("Error sending subgraph graphql query: {}", err))
+    }
+}

--- a/thegraph/src/client/subgraph_client.rs
+++ b/thegraph/src/client/subgraph_client.rs
@@ -1,0 +1,255 @@
+use alloy_primitives::aliases::BlockNumber;
+use graphql_http::graphql::IntoDocument;
+use graphql_http::http::request::IntoRequestParameters;
+use graphql_http::http_client::ResponseError;
+use serde::de::Deserialize;
+use toolshed::url::Url;
+
+use crate::types::BlockPointer;
+
+use super::queries::{
+    meta::send_subgraph_meta_query,
+    page::{send_subgraph_page_query, BlockHeight, SubgraphPageQueryResponseOpaqueEntry},
+    send_subgraph_query,
+};
+
+const DEFAULT_SUBGRAPH_PAGE_QUERY_SIZE: usize = 200;
+
+async fn send_paginated_query<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::Client,
+    subgraph_url: Url,
+    query: impl IntoDocument + Clone,
+    ticket: Option<&str>,
+    batch_size: usize,
+    latest_block: BlockNumber,
+) -> Result<(Vec<T>, BlockNumber), String> {
+    // The latest block number that the subgraph has progressed to.
+    let mut latest_block = latest_block;
+    // The last id of the previous batch.
+    let mut last_id: Option<String> = None;
+    // The block at which the query should be executed.
+    let mut query_block: Option<BlockPointer> = None;
+
+    // Vector to store the results of the paginated query.
+    let mut results = Vec::new();
+
+    loop {
+        let block_height = match query_block.as_ref() {
+            Some(block) => BlockHeight::new_with_block_hash(block.hash),
+            None => BlockHeight::new_with_block_number_gte(latest_block),
+        };
+
+        let response = send_subgraph_page_query(
+            client,
+            subgraph_url.clone(),
+            ticket,
+            query.clone(),
+            block_height,
+            batch_size,
+            last_id,
+        )
+        .await?;
+
+        let data = match response {
+            Ok(data) if !data.results.is_empty() => data,
+            Ok(_) => break,
+            Err(err) => match err {
+                ResponseError::Empty => break,
+                ResponseError::Failure { errors } => {
+                    let errors = errors
+                        .into_iter()
+                        .map(|err| err.message)
+                        .collect::<Vec<String>>();
+
+                    if errors
+                        .iter()
+                        .any(|err| err.contains("no block with that hash found"))
+                    {
+                        tracing::info!("Reorg detected. Restarting query to try a new block.");
+
+                        last_id = None;
+                        query_block = None;
+                        continue;
+                    }
+
+                    return Err(errors.join(", "));
+                }
+            },
+        };
+
+        last_id = Some(
+            serde_json::from_str::<SubgraphPageQueryResponseOpaqueEntry>(
+                data.results.last().unwrap().get(),
+            )
+            .map_err(|_| "failed to extract id for last entry".to_string())?
+            .id,
+        );
+        query_block = Some(data.meta.block);
+
+        for entry in data.results {
+            results.push(serde_json::from_str::<T>(entry.get()).map_err(|err| err.to_string())?);
+        }
+    }
+
+    if let Some(block) = query_block {
+        latest_block = block.number;
+    }
+
+    Ok((results, latest_block))
+}
+
+/// A client for interacting with a subgraph.
+pub struct Client {
+    http_client: reqwest::Client,
+    subgraph_url: Url,
+
+    /// The request authentication bearer token.
+    ///
+    /// This is token is inserted in the `Authentication` header.
+    auth_token: Option<String>,
+
+    /// The latest block number that the subgraph has progressed to.
+    /// This is set to 0 initially and updated after each paginated query.
+    latest_block: BlockNumber,
+
+    /// The number of entities to fetch per paginated query.
+    page_size: usize,
+}
+
+impl Client {
+    /// Create a new client with default settings.
+    ///
+    /// The default settings are:
+    /// - No authentication token
+    /// - Page size of 200 entities per query
+    /// - Latest block number of 0
+    pub fn new(http_client: reqwest::Client, subgraph_url: Url) -> Self {
+        Self {
+            http_client,
+            subgraph_url,
+            auth_token: None,
+            latest_block: 0,
+            page_size: DEFAULT_SUBGRAPH_PAGE_QUERY_SIZE,
+        }
+    }
+
+    /// Create a new client builder.
+    ///
+    /// The builder allows for configuring the client before building it.
+    ///
+    /// Example:
+    /// ```text
+    /// let client = SubgraphClient::builder(http_client, subgraph_url)
+    ///     .with_auth_token(Some(ticket))
+    ///     .with_page_size(100)
+    ///     .with_subgraph_latest_block(18627000)
+    ///     .build();
+    /// ```
+    pub fn builder(http_client: reqwest::Client, subgraph_url: Url) -> ClientBuilder {
+        ClientBuilder::new(http_client, subgraph_url)
+    }
+
+    pub async fn query<T: for<'de> Deserialize<'de>>(
+        &self,
+        query: impl IntoRequestParameters + Send,
+    ) -> Result<T, String> {
+        send_subgraph_query::<T>(
+            &self.http_client,
+            self.subgraph_url.clone(),
+            self.auth_token.as_deref(),
+            query,
+        )
+        .await
+    }
+
+    pub async fn paginated_query<T: for<'de> Deserialize<'de>>(
+        &mut self,
+        query: impl IntoDocument + Clone,
+    ) -> Result<Vec<T>, String> {
+        // Graph-node is rejecting values of `number_gte:0` on subgraphs with a larger `startBlock`.
+        // This forces us to request the latest block number from the subgraph before sending the
+        // paginated query.
+        // TODO: delete when resolved
+        if self.latest_block == 0 {
+            let init = send_subgraph_meta_query(
+                &self.http_client,
+                self.subgraph_url.clone(),
+                self.auth_token.as_deref(),
+            )
+            .await?;
+
+            self.latest_block = init.meta.block.number;
+        }
+
+        // Send the paginated query.
+        let (results, latest_block) = send_paginated_query(
+            &self.http_client,
+            self.subgraph_url.clone(),
+            query,
+            self.auth_token.as_deref(),
+            self.page_size,
+            self.latest_block,
+        )
+        .await?;
+
+        self.latest_block = latest_block;
+
+        Ok(results)
+    }
+}
+
+/// A builder for constructing a subgraph client.
+pub struct ClientBuilder {
+    http_client: reqwest::Client,
+    subgraph_url: Url,
+    auth_token: Option<String>,
+    latest_block: BlockNumber,
+    page_size: usize,
+}
+
+impl ClientBuilder {
+    fn new(http_client: reqwest::Client, subgraph_url: Url) -> Self {
+        Self {
+            http_client,
+            subgraph_url,
+            auth_token: None,
+            latest_block: 0,
+            page_size: DEFAULT_SUBGRAPH_PAGE_QUERY_SIZE,
+        }
+    }
+
+    /// Set request authentication token.
+    ///
+    /// By default all requests are issued non-authenticated.
+    pub fn with_auth_token(mut self, token: Option<String>) -> Self {
+        self.auth_token = token;
+        self
+    }
+
+    /// Set the number of entities to fetch per page query.
+    ///
+    /// The default value is 200 entities per query.
+    pub fn with_page_size(mut self, size: usize) -> Self {
+        debug_assert_ne!(size, 0, "page size must be greater than 0");
+        self.page_size = size;
+        self
+    }
+
+    /// Set the latest block number that the subgraph has progressed to.
+    ///
+    /// The default value is 0.
+    pub fn with_subgraph_latest_block(mut self, latest_block: BlockNumber) -> Self {
+        self.latest_block = latest_block;
+        self
+    }
+
+    pub fn build(self) -> Client {
+        Client {
+            http_client: self.http_client,
+            subgraph_url: self.subgraph_url,
+            auth_token: self.auth_token,
+            latest_block: self.latest_block,
+            page_size: self.page_size,
+        }
+    }
+}

--- a/thegraph/src/lib.rs
+++ b/thegraph/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod types;
+
+#[cfg(feature = "subgraph-client")]
+pub mod client;

--- a/thegraph/src/types.rs
+++ b/thegraph/src/types.rs
@@ -1,0 +1,11 @@
+//! A collection of types used throughout The Graph network services.
+
+pub use attestation::*;
+pub use block_pointer::*;
+pub use deployment_id::*;
+pub use subgraph_id::*;
+
+pub mod attestation;
+pub mod block_pointer;
+pub mod deployment_id;
+pub mod subgraph_id;

--- a/thegraph/src/types/attestation.rs
+++ b/thegraph/src/types/attestation.rs
@@ -1,0 +1,177 @@
+use alloy_primitives::{keccak256, Address, FixedBytes, B256, U256};
+use alloy_sol_types::{Eip712Domain, SolStruct};
+use ethers_core::{
+    k256::ecdsa::SigningKey,
+    types::{RecoveryMessage, Signature},
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::deployment_id::DeploymentId;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Attestation {
+    #[serde(rename = "requestCID")]
+    pub request_cid: B256,
+    #[serde(rename = "responseCID")]
+    pub response_cid: B256,
+    #[serde(rename = "subgraphDeploymentID")]
+    pub deployment: B256,
+    pub r: B256,
+    pub s: B256,
+    pub v: u8,
+}
+
+alloy_sol_types::sol! {
+    struct Receipt {
+        bytes32 requestCID;
+        bytes32 responseCID;
+        bytes32 subgraphDeploymentID;
+    }
+}
+
+pub fn eip712_domain(chain_id: U256, dispute_manager: Address) -> Eip712Domain {
+    let salt: B256 = "a070ffb1cd7409649bf77822cce74495468e06dbfaef09556838bf188679b9c2"
+        .parse()
+        .unwrap();
+    Eip712Domain {
+        name: Some("Graph Protocol".into()),
+        version: Some("0".into()),
+        chain_id: Some(chain_id),
+        verifying_contract: Some(dispute_manager),
+        salt: Some(salt),
+    }
+}
+
+pub fn create(
+    domain: &Eip712Domain,
+    signer: &SigningKey,
+    deployment: &DeploymentId,
+    request: &str,
+    response: &str,
+) -> Attestation {
+    let msg = Receipt {
+        requestCID: keccak256(request),
+        responseCID: keccak256(response),
+        subgraphDeploymentID: deployment.0,
+    };
+    let hash = msg.eip712_signing_hash(domain);
+    let (signature, recovery) = signer.sign_prehash_recoverable(&hash.0).unwrap();
+    Attestation {
+        request_cid: msg.requestCID,
+        response_cid: msg.responseCID,
+        deployment: deployment.0,
+        r: FixedBytes(signature.r().to_bytes().into()),
+        s: FixedBytes(signature.s().to_bytes().into()),
+        v: recovery.to_byte(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Error)]
+pub enum VerificationError {
+    #[error("invalid request hash")]
+    InvalidRequestHash,
+    #[error("invalid response hash")]
+    InvalidResponseHash,
+    #[error("failed to recover signer")]
+    FailedSignerRecovery,
+    #[error("recovered signer is not expected")]
+    RecoveredSignerNotExpected,
+}
+
+pub fn verify(
+    domain: &Eip712Domain,
+    attestation: &Attestation,
+    expected_signer: &Address,
+    request: &str,
+    response: &str,
+) -> Result<(), VerificationError> {
+    if attestation.request_cid != keccak256(request) {
+        return Err(VerificationError::InvalidRequestHash);
+    }
+    if attestation.response_cid != keccak256(response) {
+        return Err(VerificationError::InvalidResponseHash);
+    }
+    let msg = Receipt {
+        requestCID: attestation.request_cid,
+        responseCID: attestation.response_cid,
+        subgraphDeploymentID: attestation.deployment,
+    };
+    let signing_hash: B256 = msg.eip712_signing_hash(domain);
+    let signature = Signature {
+        r: attestation.r.0.into(),
+        s: attestation.s.0.into(),
+        v: attestation.v.into(),
+    };
+    let signer = signature
+        .recover(RecoveryMessage::Hash(signing_hash.0.into()))
+        .map_err(|_| VerificationError::FailedSignerRecovery)?;
+    if signer.0 != expected_signer {
+        return Err(VerificationError::RecoveredSignerNotExpected);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn domain() -> Eip712Domain {
+        eip712_domain(
+            U256::from_str_radix("1337", 10).unwrap(),
+            "16DEF7E0108A5467A106dbD7537f8591f470342E".parse().unwrap(),
+        )
+    }
+
+    fn signer() -> (Address, SigningKey) {
+        let address = "90f8bf6a479f320ead074411a4b0e7944ea8c9c1"
+            .parse::<Address>()
+            .unwrap();
+        let signing_key = SigningKey::from_slice(
+            "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d"
+                .parse::<B256>()
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        (address, signing_key)
+    }
+
+    fn deployment() -> DeploymentId {
+        "QmeVg9Da6uyBvjUEy5JqCgw2VKdkTxjPvcYuE5riGpkqw1"
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn verify_attestation() {
+        let request = "foo";
+        let response = "bar";
+        let attestation = create(&domain(), &signer().1, &deployment(), request, response);
+        let check = verify(&domain(), &attestation, &signer().0, request, response);
+        assert_eq!(check, Ok(()));
+    }
+
+    /// verify attestation created by old indexer-native module from TS indexer implementation
+    #[test]
+    fn verfiy_old_attestation() {
+        let attestation = Attestation {
+            request_cid: "41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d"
+                .parse()
+                .unwrap(),
+            response_cid: "435cd288e3694b535549c3af56ad805c149f92961bf84a1c647f7d86fc2431b4"
+                .parse()
+                .unwrap(),
+            deployment: deployment().0,
+            r: "e1fb47e7f0b278d4c88564c3a3b46180e476edcb2b783f253f3eec3b36f8fd4f"
+                .parse()
+                .unwrap(),
+            s: "467a881937edf2faf76e2e497085caf370c9689a1d83b245030757f70a1f64de"
+                .parse()
+                .unwrap(),
+            v: 28,
+        };
+        let check = verify(&domain(), &attestation, &signer().0, "foo", "bar");
+        assert_eq!(check, Ok(()));
+    }
+}

--- a/thegraph/src/types/block_pointer.rs
+++ b/thegraph/src/types/block_pointer.rs
@@ -1,0 +1,8 @@
+use alloy_primitives::{BlockHash, BlockNumber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct BlockPointer {
+    pub number: BlockNumber,
+    pub hash: BlockHash,
+}

--- a/thegraph/src/types/deployment_id.rs
+++ b/thegraph/src/types/deployment_id.rs
@@ -1,0 +1,254 @@
+use alloy_primitives::B256;
+use async_graphql::Scalar;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+/// A Subgraph's Deployment ID represents unique identifier for a deployed subgraph on The Graph.
+/// This is the content ID of the subgraph's manifest.
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SerializeDisplay, DeserializeFromStr,
+)]
+pub struct DeploymentId(pub B256);
+
+fn parse_cidv0(value: &str) -> Result<B256, DeploymentIdError> {
+    if value.len() != 46 {
+        return Err(DeploymentIdError::InvalidIpfsHashLength {
+            value: value.to_string(),
+            length: value.len(),
+        });
+    }
+
+    let mut decoded = [0_u8; 34];
+    bs58::decode(value)
+        .onto(&mut decoded)
+        .map_err(|e| DeploymentIdError::InvalidIpfsHash {
+            value: value.to_string(),
+            error: e,
+        })?;
+    let mut bytes = [0_u8; 32];
+    bytes.copy_from_slice(&decoded[2..]);
+
+    Ok(bytes.into())
+}
+
+/// Attempt to parse a 32-byte hex string.
+fn parse_hexstr(value: &str) -> Result<B256, DeploymentIdError> {
+    value
+        .parse::<B256>()
+        .map_err(|e| DeploymentIdError::InvalidHexString {
+            value: value.to_string(),
+            error: format!("{}", e),
+        })
+}
+
+/// Format bytes as a CIDv0.
+fn format_cidv0(bytes: B256) -> String {
+    let mut buf = [0_u8; 34];
+    buf[0..2].copy_from_slice(&[0x12, 0x20]);
+    buf[2..].copy_from_slice(bytes.as_slice());
+    bs58::encode(buf).into_string()
+}
+
+/// Subgraph deployment ID parsing error.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DeploymentIdError {
+    /// Invalid IPFS hash length. The input string must 46 characters long.
+    #[error("invalid IPFS / CIDv0 hash length {length}: {value} (length must be 46)")]
+    InvalidIpfsHashLength { value: String, length: usize },
+
+    /// Invalid IPFS hash format. The input hash string could not be decoded as a CIDv0.
+    #[error("invalid IPFS / CIDv0 hash \"{value}\": {error}")]
+    InvalidIpfsHash {
+        value: String,
+        error: bs58::decode::Error,
+    },
+
+    /// Invalid hex string format. The input hex string could not be decoded.
+    #[error("invalid hex string \"{value}\": {error}")]
+    InvalidHexString { value: String, error: String },
+}
+
+impl std::str::FromStr for DeploymentId {
+    type Err = DeploymentIdError;
+
+    /// Parse a deployment ID from a 32-byte hex string or a base58-encoded IPFS hash (CIDv0).
+    fn from_str(hash: &str) -> Result<Self, Self::Err> {
+        if hash.starts_with("Qm") {
+            // Attempt to decode IPFS hash (CIDv0)
+            Ok(Self(parse_cidv0(hash)?))
+        } else {
+            // Attempt to decode 32-byte hex string
+            Ok(Self(parse_hexstr(hash)?))
+        }
+    }
+}
+
+impl std::fmt::Display for DeploymentId {
+    /// Encode the deployment ID as CIDv0 (base58-encoded sha256-hash).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format_cidv0(self.0))
+    }
+}
+
+impl std::fmt::Debug for DeploymentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl std::fmt::LowerHex for DeploymentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+#[Scalar]
+impl async_graphql::ScalarType for DeploymentId {
+    fn parse(value: async_graphql::Value) -> async_graphql::InputValueResult<Self> {
+        if let async_graphql::Value::String(value) = &value {
+            Ok(value.parse::<DeploymentId>()?)
+        } else {
+            Err(async_graphql::InputValueError::expected_type(value))
+        }
+    }
+
+    fn to_value(&self) -> async_graphql::Value {
+        // Convert to CIDv0 (Qm... base58-encoded sha256-hash)
+        async_graphql::Value::String(self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy_primitives::B256;
+    use assert_matches::assert_matches;
+
+    use super::{format_cidv0, parse_cidv0, parse_hexstr, DeploymentId, DeploymentIdError};
+
+    const VALID_CID: &str = "QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz";
+    const VALID_HEX: &str = "0x7d5a99f603f231d53a4f39d1521f98d2e8bb279cf29bebfd0687dc98458e7f89";
+
+    #[test]
+    fn parse_valid_cidv0() {
+        //// Given
+        let valid_cid = VALID_CID;
+        let expected_bytes = VALID_HEX.parse::<B256>().unwrap();
+
+        //// When
+        let parsed_id = parse_cidv0(valid_cid);
+
+        //// Then
+        assert_matches!(parsed_id, Ok(id) => {
+            assert_eq!(id, expected_bytes);
+        });
+    }
+
+    #[test]
+    fn parse_invalid_lenght_cidv0() {
+        //// Given
+        let invalid_cid = "QmA";
+
+        //// When
+        let parsed_id = parse_cidv0(invalid_cid);
+
+        //// Then
+        assert_matches!(parsed_id, Err(err) => {
+            assert_eq!(err, DeploymentIdError::InvalidIpfsHashLength {
+                value: invalid_cid.to_string(),
+                length: invalid_cid.len(),
+            });
+        });
+    }
+
+    #[test]
+    fn parse_invalid_encoding_cidv0() {
+        //// Given
+        let invalid_cid = "QmfVqZ9gPyMdU6TznRUh+Y0ui7J5zym+v9BofcmEWOf4k=";
+
+        //// When
+        let parsed_id = parse_cidv0(invalid_cid);
+
+        //// Then
+        assert_matches!(parsed_id, Err(err) => {
+            assert_eq!(err, DeploymentIdError::InvalidIpfsHash {
+                value: invalid_cid.to_string(),
+                error: bs58::decode::Error::InvalidCharacter {
+                    character: '+',
+                    index: 20,
+                },
+            });
+        });
+    }
+
+    #[test]
+    fn parse_valid_hexstr() {
+        //// Given
+        let valid_hex = VALID_HEX;
+        let expected_bytes = VALID_HEX.parse::<B256>().unwrap();
+
+        //// When
+        let parsed_id = parse_hexstr(valid_hex);
+
+        //// Then
+        assert_matches!(parsed_id, Ok(id) => {
+            assert_eq!(id, expected_bytes);
+        });
+    }
+
+    #[test]
+    fn parse_invalid_hexstr() {
+        //// Given
+        let invalid_hex = "0x0123456789ABCDEF";
+
+        //// When
+        let parsed_id = parse_hexstr(invalid_hex);
+
+        //// Then
+        assert_matches!(parsed_id, Err(err) => {
+            assert_eq!(err, DeploymentIdError::InvalidHexString {
+                value: invalid_hex.to_string(),
+                error: "Invalid string length".to_string(),
+            });
+        });
+    }
+
+    #[test]
+    fn format_into_cidv0() {
+        //// Given
+        let bytes = VALID_HEX.parse::<B256>().unwrap();
+        let expected_cid = VALID_CID;
+
+        //// When
+        let cid = format_cidv0(bytes);
+
+        //// Then
+        assert_eq!(cid, expected_cid);
+    }
+
+    #[test]
+    fn deployment_id_equality() {
+        //// Given
+        let valid_cid = VALID_CID;
+        let valid_hex = VALID_HEX;
+
+        let expected_id = DeploymentId(VALID_HEX.parse().unwrap());
+        let expected_repr = VALID_CID;
+
+        //// When
+        let parsed_id1 = DeploymentId::from_str(valid_cid);
+        let parsed_id2 = DeploymentId::from_str(valid_hex);
+
+        //// Then
+        assert_matches!((parsed_id1, parsed_id2), (Ok(id1), Ok(id2)) => {
+            // Assert the two IDs internal representation is correct
+            assert_eq!(id1, expected_id);
+            assert_eq!(id2, expected_id);
+
+            // Assert the two IDs are equal and displayed in CIDv0 format
+            assert_eq!(id1, id2);
+            assert_eq!(id1.to_string(), expected_repr);
+            assert_eq!(id2.to_string(), expected_repr);
+        });
+    }
+}

--- a/thegraph/src/types/subgraph_id.rs
+++ b/thegraph/src/types/subgraph_id.rs
@@ -1,0 +1,196 @@
+use alloy_primitives::{Address, B256};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use sha3::{Digest as _, Keccak256};
+
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SerializeDisplay, DeserializeFromStr,
+)]
+pub struct SubgraphId(pub B256);
+
+/// Attempt to parse a Subgraph ID in v1 format:
+/// ```text
+/// 0x <hex account_id> - <decimal sequence_id>
+/// ```
+fn parse_v1(value: &str) -> Option<B256> {
+    let (account_id, sequence_id) = value.split_once('-')?;
+    let account = account_id.parse::<Address>().ok()?;
+
+    // Assuming u256 big-endian, since that's the word-size of the EVM
+    let mut sequence_word = [0_u8; 32];
+    let sequence_number = sequence_id.parse::<u64>().ok()?.to_be_bytes();
+    sequence_word[24..].copy_from_slice(&sequence_number);
+
+    let hash: [u8; 32] = {
+        let mut hasher = Keccak256::default();
+        hasher.update(account.0);
+        hasher.update(sequence_word);
+        hasher.finalize().into()
+    };
+
+    Some(hash.into())
+}
+
+/// Attempt to parse a Subgraph ID in v2 format:
+///
+/// ```text
+/// base58(sha256(<subgraph_id>))
+/// ```
+///
+/// If the input is not valid base58, or the decoded hash is not 32 bytes, returns `None`.
+fn parse_v2(value: &str) -> Option<B256> {
+    let mut hash = [0_u8; 32];
+    let len = bs58::decode(value).onto(&mut hash).ok()?;
+    hash.rotate_right(32 - len);
+    Some(hash.into())
+}
+
+impl std::str::FromStr for SubgraphId {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Some(v2) = parse_v2(value) {
+            return Ok(Self(v2));
+        }
+        if let Some(v1) = parse_v1(value) {
+            return Ok(Self(v1));
+        }
+        Err("invalid subgraph ID")
+    }
+}
+
+impl std::fmt::Display for SubgraphId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&bs58::encode(self.0.as_slice()).into_string())
+    }
+}
+
+impl std::fmt::Debug for SubgraphId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use assert_matches::assert_matches;
+
+    use super::{parse_v1, parse_v2, SubgraphId};
+
+    const ID_V1: &str = "0xdeadbeef678b513255cea949017921c8c9f6ef82-1";
+    const ID_V2: &str = "7xB3yxxD8okmq4dZPky3eP1nYRgLfZrwMyUQBGo32t4U";
+
+    const EXPECTED_ID_BYTES: &str =
+        "0x67486e65165b1474898247760a4b852d70d95782c6325960e5b6b4fd82fed1bd";
+
+    #[test]
+    fn parse_valid_v1_id() {
+        //// Given
+        let valid_id = ID_V1;
+        let expected_id = EXPECTED_ID_BYTES.parse::<B256>().unwrap();
+
+        //// When
+        let parsed_id = parse_v1(valid_id);
+
+        //// Then
+        assert_matches!(parsed_id, Some(id) => {
+            assert_eq!(id, expected_id);
+        });
+    }
+
+    #[test]
+    fn parse_invalid_v1_id() {
+        //// Given
+        let invalid_id = ID_V2;
+
+        //// When
+        let parsed_id = parse_v1(invalid_id);
+
+        //// Then
+        assert_matches!(parsed_id, None);
+    }
+
+    #[test]
+    fn parse_valid_v2_id() {
+        //// Given
+        let valid_id = ID_V2;
+        let expected_id = EXPECTED_ID_BYTES.parse::<B256>().unwrap();
+
+        //// When
+        let parsed_id = parse_v2(valid_id);
+
+        //// Then
+        assert_matches!(parsed_id, Some(id) => {
+            assert_eq!(id, expected_id);
+        });
+    }
+
+    #[test]
+    fn decode_subgraph_id_from_v1_string() {
+        //// Given
+        let valid_id = ID_V1;
+        let expected_id = EXPECTED_ID_BYTES.parse::<B256>().unwrap();
+
+        //// When
+        let parsed_id = valid_id.parse::<SubgraphId>();
+
+        //// Then
+        assert_matches!(parsed_id, Ok(id) => {
+            assert_eq!(id.0, expected_id);
+        });
+    }
+
+    #[test]
+    fn decode_subgraph_id_from_v2_string() {
+        //// Given
+        let valid_id = ID_V2;
+        let expected_id = EXPECTED_ID_BYTES.parse::<B256>().unwrap();
+
+        //// When
+        let parsed_id = valid_id.parse::<SubgraphId>();
+
+        //// Then
+        assert_matches!(parsed_id, Ok(id) => {
+            assert_eq!(id.0, expected_id);
+        });
+    }
+
+    #[test]
+    fn decode_failure_on_invalid_string() {
+        //// Given
+        let invalid_id = "invalid";
+
+        //// When
+        let parsed_id = invalid_id.parse::<SubgraphId>();
+
+        //// Then
+        assert_matches!(parsed_id, Err(err) => {
+            assert_eq!(err, "invalid subgraph ID");
+        });
+    }
+
+    #[test]
+    fn subgraph_equality() {
+        //// Given
+        let valid_v1 = ID_V1;
+        let valid_v2 = ID_V2;
+
+        let expected_id = SubgraphId(EXPECTED_ID_BYTES.parse().unwrap());
+        let expected_repr = ID_V2;
+
+        //// When
+        let parsed_id1 = valid_v1.parse::<SubgraphId>();
+        let parsed_id2 = valid_v2.parse::<SubgraphId>();
+
+        //// Then
+        assert_matches!((parsed_id1, parsed_id2), (Ok(id1), Ok(id2)) => {
+            // Assert the two IDs internal representation is correct
+            assert_eq!(id1, expected_id);
+            assert_eq!(id2, expected_id);
+
+            // Assert the two IDs are equal and displayed in v2 format
+            assert_eq!(id1, id2);
+            assert_eq!(id1.to_string(), expected_repr);
+            assert_eq!(id2.to_string(), expected_repr);
+        });
+    }
+}

--- a/thegraph/tests/it_subgraph_client.rs
+++ b/thegraph/tests/it_subgraph_client.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "subgraph-client")]
+#![allow(clippy::four_forward_slashes)]
+
+use assert_matches::assert_matches;
+use serde::Deserialize;
+use toolshed::thegraph::{BlockPointer, SubgraphId};
+use toolshed::url::Url;
+
+use thegraph::client::queries::meta::{send_subgraph_meta_query, SubgraphMetaQueryResponse};
+use thegraph::client::queries::page::{send_subgraph_page_query, BlockHeight};
+use thegraph::client::Client as SubgraphClient;
+
+/// Test helper to parse a URL.
+fn test_url(url: &str) -> Url {
+    url.parse().expect("Invalid URL")
+}
+
+/// Test helper to get the test query key from the environment.
+fn test_query_key() -> String {
+    std::env::var("THEGRAPH_TEST_QUERY_KEY").expect("Missing THEGRAPH_TEST_QUERY_KEY")
+}
+
+#[test_with::env(THEGRAPH_TEST_QUERY_KEY)]
+#[tokio::test]
+async fn send_subgraph_meta_query_request() {
+    //// Given
+    let ticket = test_query_key();
+
+    let http_client = reqwest::Client::new();
+    let subgraph_url = test_url("https://gateway.thegraph.com/api/deployments/id/QmRbgjyzEgfxGbodu6itfkXCQ5KA9oGxKscrcQ9QuF88oT");
+
+    //// When
+    let req_fut = send_subgraph_meta_query(&http_client, subgraph_url, Some(&ticket));
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), req_fut)
+        .await
+        .expect("Timeout on subgraph meta query");
+
+    //// Then
+    // Assert the query succeeded and we get a non-empty block number and hash.
+    assert_matches!(res, Ok(SubgraphMetaQueryResponse { meta }) => {
+        assert!(meta.block.number > 0);
+        assert!(!meta.block.hash.is_empty());
+    });
+}
+
+#[test_with::env(THEGRAPH_TEST_QUERY_KEY)]
+#[tokio::test]
+async fn send_subgraph_page_query_request() {
+    //// Given
+    const PAGE_REQUEST_BATCH_SIZE: usize = 6;
+
+    let ticket = test_query_key();
+
+    let http_client = reqwest::Client::new();
+    let subgraph_url = test_url("https://gateway.thegraph.com/api/deployments/id/QmRbgjyzEgfxGbodu6itfkXCQ5KA9oGxKscrcQ9QuF88oT");
+
+    // Query all subgraph ids.
+    const SUBGRAPHS_QUERY_DOCUMENT: &str = r#"
+        subgraphs(
+            block: $block
+            orderBy: id, orderDirection: asc
+            first: $first
+            where: {
+                id_gt: $last
+                entityVersion: 2
+            }
+        ) {
+            id
+        }
+        "#;
+
+    //// When
+    let req_fut = send_subgraph_page_query(
+        &http_client,
+        subgraph_url,
+        Some(&ticket),
+        SUBGRAPHS_QUERY_DOCUMENT,
+        BlockHeight::new_with_block_number_gte(18627000),
+        PAGE_REQUEST_BATCH_SIZE,
+        None,
+    );
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), req_fut)
+        .await
+        .expect("Timeout on subgraph meta query");
+
+    //// Then
+    assert_matches!(res, Ok(Ok(resp)) => {
+        // Assert meta data is present and valid.
+        assert!(resp.meta.block.number > 0);
+        assert!(!resp.meta.block.hash.is_empty());
+
+        // Assert the results are present and the correct size.
+        assert_eq!(resp.results.len(), PAGE_REQUEST_BATCH_SIZE);
+    });
+}
+
+#[test_with::env(THEGRAPH_TEST_QUERY_KEY)]
+#[tokio::test]
+async fn client_send_query() {
+    //// Given
+    let ticket = test_query_key();
+
+    let http_client = reqwest::Client::new();
+    let subgraph_url = test_url("https://gateway.thegraph.com/api/deployments/id/QmRbgjyzEgfxGbodu6itfkXCQ5KA9oGxKscrcQ9QuF88oT");
+
+    let client = SubgraphClient::builder(http_client, subgraph_url)
+        .with_auth_token(Some(ticket))
+        .build();
+
+    // Subgraph meta query
+    const SUBGRAPH_META_QUERY_DOCUMENT: &str = r#"{ meta: _meta { block { number hash } } }"#;
+
+    #[derive(Debug, Deserialize)]
+    struct Meta {
+        block: BlockPointer,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SubgraphMetaQueryResponse {
+        meta: Meta,
+    }
+
+    //// When
+    let req_fut = client.query::<SubgraphMetaQueryResponse>(SUBGRAPH_META_QUERY_DOCUMENT);
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), req_fut)
+        .await
+        .expect("Timeout on subgraph meta query");
+
+    //// Then
+    // Assert the query succeeded and we get a non-empty block number and hash.
+    assert_matches!(res, Ok(SubgraphMetaQueryResponse { meta }) => {
+        assert!(meta.block.number > 0);
+        assert!(!meta.block.hash.is_empty());
+    });
+}
+
+#[test_with::env(THEGRAPH_TEST_QUERY_KEY)]
+#[tokio::test]
+async fn send_subgraph_paginated() {
+    //// Given
+    let ticket = test_query_key();
+    let subgraph_url = test_url("https://gateway.thegraph.com/api/deployments/id/QmRbgjyzEgfxGbodu6itfkXCQ5KA9oGxKscrcQ9QuF88oT");
+
+    let http_client = reqwest::Client::new();
+
+    let mut client = SubgraphClient::builder(http_client, subgraph_url)
+        .with_auth_token(Some(ticket))
+        .build();
+
+    // Query all subgraph ids.
+    const SUBGRAPHS_QUERY_DOCUMENT: &str = r#"
+        subgraphs(
+            block: $block
+            orderBy: id, orderDirection: asc
+            first: $first
+            where: {
+                id_gt: $last
+                entityVersion: 2
+            }
+        ) {
+            id
+        }
+        "#;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Subgraph {
+        pub id: SubgraphId,
+    }
+
+    //// When
+    let req_fut = client.paginated_query::<Subgraph>(SUBGRAPHS_QUERY_DOCUMENT);
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), req_fut)
+        .await
+        .expect("Timeout on subgraph paginated query");
+
+    //// Then
+    // Assert the query succeeded and we got a non-empty list of active subscriptions.
+    assert_matches!(res, Ok(vec) => {
+        assert!(!vec.is_empty());
+    });
+}

--- a/toolshed/src/lib.rs
+++ b/toolshed/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bytes;
 pub mod epoch_cache;
+#[deprecated(since = "0.4.0", note = "use `thegraph` crate instead")]
 pub mod thegraph;
 #[cfg(feature = "url")]
 pub mod url;


### PR DESCRIPTION
This PR introduces the `thegraph` crate.

- [x] Add `thegraph::types` module containing the _The Graph_ common types (from the `toolshed` crate).
- [x] Added under the `thegraph::client` module the Gateway's graphql-http based Subgraph client.
- [x] Deprecated the `toolshed::thegraph` module in favor of the `thegraph` crate.