### PR TITLE
feat(graphql-http): add async-graphql request compat shim

### DIFF
--- a/graphql-http/Cargo.toml
+++ b/graphql-http/Cargo.toml
@@ -9,12 +9,14 @@ rust-version = "1.63.0"
 http-reqwest = ["dep:async-trait", "dep:reqwest"]
 compat-graphql-client = ["dep:graphql_client"]
 compat-graphql-parser = ["dep:graphql-parser"]
+compat-async-graphql = ["dep:async-graphql"]
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = "1.0"
+async-graphql = { version = "6.0", optional = true }
 async-trait = { version = "0.1", optional = true }
-graphql-parser = { version = "0.4.0", optional = true }
-graphql_client = { version = "0.13.0", optional = true }
+graphql-parser = { version = "0.4", optional = true }
+graphql_client = { version = "0.13", optional = true }
 reqwest = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/graphql-http/src/http/request.rs
+++ b/graphql-http/src/http/request.rs
@@ -40,7 +40,7 @@ impl IntoRequestParameters for RequestParameters {
     }
 }
 
-// Any type implementing `IntoQueryWithVariables` (or `IntoQuery`) can be converted into
+// Any type implementing `IntoDocumentWithVariables` (or `IntoDocument`) can be converted into
 // `RequestParameters`.
 impl<T> IntoRequestParameters for T
 where


### PR DESCRIPTION
The `async-graphql` is another rust GraphQL crate we use in our projects. 

This PR adds a compatibility shim, gated by the `compat-async-graphql` feature, so one can use an `async_graphql::Request` with the Reqwest-based client.