### PR TITLE
feat(thegraph): add proof-of-indexing to the types module

### DIFF
--- a/thegraph/src/types.rs
+++ b/thegraph/src/types.rs
@@ -3,11 +3,13 @@
 pub use attestation::*;
 pub use block_pointer::*;
 pub use deployment_id::*;
+pub use poi::*;
 pub use primitives::*;
 pub use subgraph_id::*;
 
 pub mod attestation;
 pub mod block_pointer;
 pub mod deployment_id;
+pub mod poi;
 mod primitives;
 pub mod subgraph_id;

--- a/thegraph/src/types/poi.rs
+++ b/thegraph/src/types/poi.rs
@@ -1,0 +1,11 @@
+//! A Proof of Indexing (POI) a cryptographic proof submitted by indexers to demonstrate that they
+//! have  accurately indexed a subgraph.
+//!
+//! The POI is essentially a signature over a message digest that is generated during the indexing
+//! of a subgraph from genesis. Each time a subgraph’s state is updated, so does the message digest.
+
+use super::primitives::B256;
+
+/// A Proof of Indexing (POI) a cryptographic proof submitted by indexers to demonstrate that they
+/// have  accurately indexed a subgraph.
+pub type ProofOfIndexing = B256;

--- a/thegraph/src/types/poi.rs
+++ b/thegraph/src/types/poi.rs
@@ -1,5 +1,5 @@
 //! A Proof of Indexing (POI) a cryptographic proof submitted by indexers to demonstrate that they
-//! have  accurately indexed a subgraph.
+//! have accurately indexed a subgraph.
 //!
 //! The POI is essentially a signature over a message digest that is generated during the indexing
 //! of a subgraph from genesis. Each time a subgraph’s state is updated, so does the message digest.


### PR DESCRIPTION
This small PR adds the POI (as a type alias) to the `thegraph` crate well-known types module.