### PR TITLE
feat(thegraph): add support for subscription payments ticket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df496257fe2fae392687ef30207325c50c68520108a94798b0c6cc1a6102f70"
+dependencies = [
+ "num_enum",
+ "serde",
+ "strum",
 ]
 
 [[package]]
@@ -374,6 +396,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +523,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
+ "sha2",
  "tinyvec",
 ]
 
@@ -515,6 +555,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.20",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +612,68 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "coins-bip32"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
+dependencies = [
+ "base64 0.21.5",
+ "bech32",
+ "bs58",
+ "digest 0.10.7",
+ "generic-array",
+ "hex",
+ "ripemd",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "sha3",
+ "thiserror",
 ]
 
 [[package]]
@@ -631,6 +765,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -788,6 +931,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "enr"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +962,28 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac",
+ "pbkdf2 0.11.0",
+ "rand",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -852,6 +1035,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5344eea9b20effb5efeaad29418215c4d27017639fd1f908260f59cbbd226e"
+dependencies = [
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c405f24ea3a517899ba7985385c43dc4a7eb1209af3b1e0a1a32d7dcc7f8d09"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0111ead599d17a7bff6985fd5756f39ca7033edc79a31b23026a8d5d64fa95cd"
+dependencies = [
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51258120c6b47ea9d9bec0d90f9e8af71c977fbefbef8213c91bfed385fe45eb"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "dunce",
+ "ethers-core",
+ "eyre",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "syn 2.0.41",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e7a0f1197cee2b62dc89f63eff3201dbf87c283ff7e18d86d38f83b845483"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-core",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "ethers-core"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +1125,7 @@ checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
 dependencies = [
  "arrayvec",
  "bytes",
+ "cargo_metadata",
  "chrono",
  "const-hex",
  "elliptic-curve",
@@ -866,16 +1133,109 @@ dependencies = [
  "generic-array",
  "k256",
  "num_enum",
+ "once_cell",
  "open-fastrlp",
  "rand",
  "rlp",
  "serde",
  "serde_json",
  "strum",
+ "syn 2.0.41",
  "tempfile",
  "thiserror",
  "tiny-keccak",
  "unicode-xid",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681ece6eb1d10f7cf4f873059a77c04ff1de4f35c63dd7bccde8f438374fcb93"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-providers",
+ "ethers-signers",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25d6c0c9455d93d4990c06e049abf9b30daf148cf461ee939c11d88907c60816"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.5",
+ "bytes",
+ "const-hex",
+ "enr",
+ "ethers-core",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "http",
+ "instant",
+ "jsonwebtoken",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cb1b714e227bbd2d8c53528adb580b203009728b17d0d0e4119353aa9bc5532"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "const-hex",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core",
+ "rand",
+ "sha2",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f656be11ddf91bd709454d15d5bd896fbaf4cc3314e69349e4d1569f5b46cd"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -969,12 +1329,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -984,10 +1360,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-locks"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
+dependencies = [
+ "futures-channel",
+ "futures-task",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1013,11 +1410,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1027,6 +1435,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1056,6 +1473,18 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "graphql"
@@ -1186,6 +1615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "handlebars"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1645,15 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
+]
 
 [[package]]
 name = "heck"
@@ -1390,6 +1834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1866,24 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "ipnet"
@@ -1448,6 +1916,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.5",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1940,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -1545,7 +2028,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -1736,6 +2219,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2298,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +2366,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.41",
+]
 
 [[package]]
 name = "primitive-types"
@@ -2060,6 +2611,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2754,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2802,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2 0.11.0",
+ "salsa20",
+ "sha2",
 ]
 
 [[package]]
@@ -2262,6 +2867,9 @@ name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -2273,12 +2881,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.12.0-dev"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46d75f449e01f1eddbe9b00f432d616fbbd899b809c837d0fbc380496a0dd55"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -2300,6 +2930,15 @@ checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+dependencies = [
  "serde",
 ]
 
@@ -2376,6 +3015,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +3063,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2560,17 +3217,21 @@ dependencies = [
 name = "thegraph"
 version = "0.1.1"
 dependencies = [
+ "alloy-chains",
  "alloy-primitives",
  "alloy-sol-types",
  "assert_matches",
  "async-graphql",
+ "base64 0.21.5",
  "bs58",
+ "ethers",
  "ethers-core",
  "graphql-http 0.1.1 (git+https://github.com/edgeandnode/toolshed.git?tag=graphql-http-v0.1.1)",
  "indoc",
  "lazy_static",
  "reqwest",
  "serde",
+ "serde_cbor_2",
  "serde_json",
  "serde_with",
  "sha3",
@@ -2706,10 +3367,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2729,6 +3405,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -2805,6 +3483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +3565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,6 +3579,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -2918,6 +3622,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3026,6 +3740,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3191,6 +3914,25 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.0",
+ "send_wrapper 0.6.0",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/thegraph/Cargo.toml
+++ b/thegraph/Cargo.toml
@@ -7,18 +7,23 @@ rust-version = "1.67.1"
 
 [features]
 subgraph-client = ["dep:tracing", "dep:indoc", "dep:serde_json", "dep:toolshed", "toolshed/url", "dep:reqwest", "dep:graphql-http", "graphql-http/http-reqwest"]
+subscriptions = ["dep:base64", "dep:serde_cbor_2", "dep:alloy-chains", "dep:ethers"]
 
 [dependencies]
+alloy-chains = { version = "0.1", features = ["serde"], optional = true }
 alloy-primitives = { version = "0.5", features = ["serde"] }
 alloy-sol-types = "0.5"
 async-graphql = "6.0"
+base64 = { version = "0.21", optional = true }
 bs58 = "0.5"
+ethers = { version = "2.0", default-features = false, optional = true }
 ethers-core = { version = "2.0", default-features = false }
 graphql-http = { git = "https://github.com/edgeandnode/toolshed.git", tag = "graphql-http-v0.1.1", optional = true }
 indoc = { version = "2.0", optional = true }
 lazy_static = "1.4"
 reqwest = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"] }
+serde_cbor_2 = { version = "0.12.0-dev", optional = true }
 serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
 serde_with = "3.4"
 sha3 = "0.10"

--- a/thegraph/src/lib.rs
+++ b/thegraph/src/lib.rs
@@ -2,3 +2,6 @@ pub mod types;
 
 #[cfg(feature = "subgraph-client")]
 pub mod client;
+
+#[cfg(feature = "subscriptions")]
+pub mod subscriptions;

--- a/thegraph/src/subscriptions.rs
+++ b/thegraph/src/subscriptions.rs
@@ -1,0 +1,3 @@
+//! Utilities for working with the Graph Subscriptions contract.
+
+pub mod auth;

--- a/thegraph/src/subscriptions/auth.rs
+++ b/thegraph/src/subscriptions/auth.rs
@@ -1,0 +1,468 @@
+//! A subscription auth token is an authorization token that allows a user to send queries to the graph network.
+//!
+//! # Auth Token format
+//!
+//! A auth token has 2 parts:
+//!
+//!  1. Payload (containing auth token claims)
+//!  2. Signature
+//!
+//! The signature is always the last 65 bytes of the auth token. The auth token should be Base64Url encoded when they are sent
+//! to gateways along with queries.
+//!
+//! ## Payload
+//!
+//! The auth token payload must be a [CBOR](https://www.rfc-editor.org/rfc/rfc7049)-encoded map and MUST containing the
+//! following auth token claims:
+//!
+//!  1. *chain_id:* Chain ID (EIP-155) for the chain on which the subscriptions contract is deployed.
+//!  2. *contract:* Address of the subscriptions contract.
+//!  3. *signer:* Signer address that is authorized to sign the auth token. This address should be the user's address or
+//!               one of the user's authorized signers.
+//!  4. *user (optional):* User address associated with the subscription. Required to when the authorized `signer` is
+//!                        not the `user` associated with a subscription. When omitted, the `signer` is implied to be
+//!                        equal to the `user`.
+//!
+//! Other optional fields may be supported at the gateway operator's discretion. See [`AuthTokenClaims`] for other
+//! supported fields.
+//!
+//! Note that the gateway address is implied to be the owner of the subscriptions contract. In the future, we may need
+//! to explicitly identify the intended recipient gateway to prevent attacks where a gateway proxies requests.
+//!
+//! ## Signature
+//!
+//! Signing and verification of auth tokens uses an Ethereum signed message ([EIP-191](https://eips.ethereum.org/EIPS/eip-191),
+//! `personal_sign`) constructed from the auth token claims.
+//!  
+//!  - The message MUST be UTF-8 encoded.
+//!  - Fields MUST be ordered lexicographically by field name.
+//!  - Each field MUST be immediately followed by an ASCII LF character (`0x0a`).
+//!  - Each field name and value MUST be separated by `": "`.
+//!  - Any byte string value MUST be formatted as `0x` followed by its hex-encoded bytes.
+//!
+//! See [`AuthTokenClaims::to_verification_message`] method for the implementation details.
+
+use std::io::{Cursor, Write as _};
+
+pub use alloy_chains::{Chain, NamedChain};
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine as _};
+use ethers::signers::Wallet;
+use ethers_core::k256::ecdsa::SigningKey;
+use ethers_core::types::Signature;
+
+use crate::types::Address;
+
+/// Claims that are encoded in an auth token.
+#[serde_with::serde_as]
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AuthTokenClaims {
+    /// Chain ID (EIP-155) of the chain on which the subscriptions contract is deployed.
+    #[serde_as(as = "serde_with::FromInto<u64>")]
+    pub chain_id: Chain,
+
+    /// Address of the subscriptions contract.
+    pub contract: Address,
+
+    /// Signer address that is authorized to sign the auth token.
+    ///
+    /// This address should be the user's address or one of the user's authorized signers.
+    pub signer: Address,
+
+    /// User address associated with the subscription.
+    ///
+    /// Required when the authorized `signer` is not the `user` associated with a subscription. When
+    /// omitted, the `signer` is implied to be equal to the `user`.
+    #[serde(default)]
+    pub user: Option<Address>,
+
+    /// Optional name of the subscription.
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// Comma-separated list of subgraphs that can be queried with this auth token.
+    #[serde(default)]
+    pub allowed_subgraphs: Option<String>,
+
+    /// Comma-separated list of subgraph deployments that can be queried with this auth token.
+    #[serde(default)]
+    pub allowed_deployments: Option<String>,
+
+    /// Comma-separated list of origin domains that can send queries with this auth token.
+    #[serde(default)]
+    pub allowed_domains: Option<String>,
+}
+
+impl AuthTokenClaims {
+    /// Returns the user address that the auth token is for.
+    ///
+    /// If the `user` field is not set, the `signer` is address is returned.
+    pub fn user(&self) -> Address {
+        self.user.unwrap_or(self.signer)
+    }
+
+    /// Returns the verification message that must be signed by the signer address.
+    ///
+    /// The verification message is a string that contains all the claims serialized in a human-readable format
+    /// that follows these rules:
+    ///
+    ///  - The message must be UTF-8 encoded.
+    ///  - Fields must be ordered lexicographically by field name.
+    ///  - Each field must be immediately followed by an ASCII LF character (`0x0a`).
+    ///  - Each field name and value must be separated by `": "`.
+    ///  - Any byte string value must be formatted as `0x` followed by its hex-encoded bytes.
+    ///
+    /// The returned serialized message is a `String` ready to be hashed and signed.
+    fn to_verification_message(&self) -> String {
+        let mut cursor = Cursor::<Vec<u8>>::default();
+
+        if let Some(allowed_deployments) = self.allowed_deployments.as_deref() {
+            writeln!(&mut cursor, "allowed_deployments: {}", allowed_deployments).unwrap();
+        }
+        if let Some(allowed_domains) = self.allowed_domains.as_deref() {
+            writeln!(&mut cursor, "allowed_domains: {}", allowed_domains).unwrap();
+        }
+        if let Some(allowed_subgraphs) = self.allowed_subgraphs.as_deref() {
+            writeln!(&mut cursor, "allowed_subgraphs: {}", allowed_subgraphs).unwrap();
+        }
+
+        writeln!(&mut cursor, "chain_id: {}", self.chain_id.id()).unwrap();
+        writeln!(&mut cursor, "contract: {:?}", self.contract).unwrap();
+
+        if let Some(name) = self.name.as_deref() {
+            writeln!(&mut cursor, "name: {}", name).unwrap();
+        }
+
+        writeln!(&mut cursor, "signer: {:?}", self.signer).unwrap();
+
+        if let Some(user) = self.user.as_deref() {
+            writeln!(&mut cursor, "user: {:?}", user).unwrap();
+        }
+
+        String::from_utf8(cursor.into_inner()).unwrap()
+    }
+}
+
+/// Errors that can occur when encoding an auth token.
+#[derive(Debug, thiserror::Error)]
+pub enum EncodingError {
+    /// The auth token claims could not be signed.
+    #[error("failed to sign the auth token claims")]
+    ClaimsSigningError,
+
+    /// The claims could not be encoded as CBOR.
+    #[error("failed to encode claims as CBOR")]
+    ClaimsEncodingError,
+}
+
+/// Generates an auth token from the given claims and private key.
+pub fn encode_auth_token(
+    claims: &AuthTokenClaims,
+    wallet: &Wallet<SigningKey>,
+) -> Result<String, EncodingError> {
+    // Generate the claims hash and sign it.
+    let claims_hash = ethers_core::utils::hash_message(claims.to_verification_message());
+    let signature = wallet
+        .sign_hash(claims_hash)
+        .map_err(|_| EncodingError::ClaimsSigningError)?;
+
+    // Encode the claims and signature as CBOR.
+    let auth_token_bytes = {
+        let mut buf =
+            serde_cbor_2::ser::to_vec(claims).map_err(|_| EncodingError::ClaimsEncodingError)?;
+        buf.append(&mut signature.to_vec());
+        buf
+    };
+
+    // Encode the auth token as base64.
+    let auth_token = BASE64_URL_SAFE_NO_PAD.encode(auth_token_bytes);
+
+    Ok(auth_token)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    /// The auth token is not encoded in a valid base64 format.
+    ///
+    /// The auth token must be encoded in base64 with the URL-safe alphabet and without padding.
+    #[error("invalid base64 encoding")]
+    InvalidBase64Encoding,
+
+    /// The signature is not a valid 65-byte ECDSA signature.
+    #[error("invalid signature")]
+    InvalidSignature,
+
+    /// The claims are not a valid CBOR-encoded value.
+    #[error("invalid claims encoding")]
+    InvalidClaimsEncoding,
+}
+
+/// Parses an auth token from a base64-encoded string.
+///
+/// The auth token must contain the CBOR-encoded claims followed by a 65-byte ECDSA signature. Then the auth token
+/// is encoded in base64 with the URL-safe alphabet and without padding.
+pub fn parse_auth_token(value: &str) -> Result<(AuthTokenClaims, Signature), ParseError> {
+    // Decode the auth token from base64.
+    let auth_token = BASE64_URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| ParseError::InvalidBase64Encoding)?;
+
+    // Extract the signature from the end of the auth token.
+    let signature_start = auth_token.len().saturating_sub(65);
+    let signature = auth_token[signature_start..]
+        .try_into()
+        .map(Signature::from)
+        .map_err(|_| ParseError::InvalidSignature)?;
+
+    // Decode the claims from the start of the auth token.
+    let claims: AuthTokenClaims = serde_cbor_2::de::from_reader(&auth_token[..signature_start])
+        .map_err(|_| ParseError::InvalidClaimsEncoding)?;
+
+    Ok((claims, signature))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SignatureVerificationError {
+    /// The Ethereum address which was used to sign the given message could not be recovered.
+    #[error("failed to recover signer public key")]
+    SignerPublicKeyRecoveryError,
+
+    /// The recovered signer address does not match the signer address in the claims.
+    #[error("invalid signature")]
+    VerificationError,
+}
+
+/// Verifies that the given signature was signed by the signer address in the claims.
+pub fn verify_auth_token_claims(
+    claims: &AuthTokenClaims,
+    signature: &Signature,
+) -> Result<(), SignatureVerificationError> {
+    let recovery_message = ethers_core::utils::hash_message(claims.to_verification_message());
+    let signer = signature
+        .recover(recovery_message)
+        .map_err(|_| SignatureVerificationError::SignerPublicKeyRecoveryError)?;
+
+    // Verify that the recovered signer address matches the signer address in the claims.
+    if signer.as_bytes() != claims.signer {
+        return Err(SignatureVerificationError::VerificationError);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use assert_matches::assert_matches;
+    use ethers::prelude::Wallet;
+    use ethers::signers::Signer;
+
+    use crate::types::Address;
+
+    use super::{
+        encode_auth_token, parse_auth_token, verify_auth_token_claims, AuthTokenClaims, Chain,
+        ParseError, SignatureVerificationError,
+    };
+
+    #[test]
+    fn serialize_claims_into_verification_message() {
+        //* Given
+        let chain_id = Chain::dev();
+        let contract: Address = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+            .parse()
+            .expect("invalid contract address");
+
+        let wallet =
+            Wallet::from_str("0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d")
+                .expect("invalid private key");
+        let wallet_address: Address = wallet.address().as_fixed_bytes().into();
+
+        let claims = AuthTokenClaims {
+            chain_id,
+            contract,
+            signer: wallet_address,
+            user: None,
+            name: None,
+            allowed_subgraphs: None,
+            allowed_deployments: None,
+            allowed_domains: None,
+        };
+
+        let expected_message = indoc::indoc! {"
+            chain_id: 1337
+            contract: 0xe7f1725e7734ce288f8367e1bb143e90bb3f0512
+            signer: 0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1
+        "};
+
+        //* When
+        let result = claims.to_verification_message();
+
+        //* Then
+        assert_eq!(result, expected_message);
+    }
+
+    #[test]
+    fn encode_claims_and_sign_the_auth_token() {
+        //* Given
+        let chain_id = Chain::dev();
+        let contract: Address = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+            .parse()
+            .expect("invalid contract address");
+
+        let wallet =
+            Wallet::from_str("0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d")
+                .expect("invalid private key");
+        let wallet_address: Address = wallet.address().as_fixed_bytes().into();
+
+        let claims = AuthTokenClaims {
+            chain_id,
+            contract,
+            signer: wallet_address,
+            user: None,
+            name: None,
+            allowed_subgraphs: None,
+            allowed_deployments: None,
+            allowed_domains: None,
+        };
+
+        let expected_auth_token = "o2hjaGFpbl9pZBkFOWhjb250cmFjdFTn8XJedzTOKI-DZ-G7FD6Quz8FEmZzaWduZXJUkPi_akefMg6tB0QRpLDnlE6oycGJ0BmGU8gFyjO7ELgWvEc4WV1LpCUNpL4MGJTUXtzR9gktyGqD-yln-rRyPh9Pkfem5vXcgbLeni0Vdg--Gf14HA";
+
+        //* When
+        let result = encode_auth_token(&claims, &wallet);
+
+        //* Then
+        assert_matches!(result, Ok(auth_token) => {
+            assert_eq!(auth_token, expected_auth_token);
+        });
+    }
+
+    #[test]
+    fn parse_invalid_auth_token_with_invalid_base64_encoding() {
+        //* Given
+        let auth_token = "X2ludmFsaWRfYXV0aF90b2tlbl8="; // base64("_invalid_auth_token_")
+
+        //* When
+        let result = parse_auth_token(auth_token);
+
+        //* Then
+        assert_matches!(result, Err(ParseError::InvalidBase64Encoding));
+    }
+
+    #[test]
+    fn parse_invalid_auth_token_with_valid_base64_encoding() {
+        //* Given
+        let auth_token = "X2ludmFsaWRfYXV0aF90b2tlbl8"; // base64URL("_invalid_auth_token_")
+
+        //* When
+        let result = parse_auth_token(auth_token);
+
+        //* Then
+        assert_matches!(result, Err(ParseError::InvalidSignature));
+    }
+
+    #[test]
+    fn parse_valid_auth_token() {
+        //* Given
+        let expected_chain_id = Chain::dev();
+        let expected_contract: Address = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+            .parse()
+            .expect("invalid contract address");
+
+        let expected_user: Address = "0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1"
+            .parse()
+            .expect("invalid address");
+
+        let auth_token = "o2hjaGFpbl9pZBkFOWhjb250cmFjdFTn8XJedzTOKI-DZ-G7FD6Quz8FEmZzaWduZXJUkPi_akefMg6tB0QRpLDnlE6oycGJ0BmGU8gFyjO7ELgWvEc4WV1LpCUNpL4MGJTUXtzR9gktyGqD-yln-rRyPh9Pkfem5vXcgbLeni0Vdg--Gf14HA";
+
+        //* When
+        let result = parse_auth_token(auth_token);
+
+        //* Then
+        assert_matches!(result, Ok((claims, _signature)) => {
+            // Assert auth_token claims
+            assert_eq!(claims.chain_id, expected_chain_id);
+            assert_eq!(claims.contract, expected_contract);
+            assert_eq!(claims.signer, expected_user);
+            assert_eq!(claims.user, None);
+
+            assert_eq!(claims.user(), expected_user);
+        });
+    }
+
+    #[test]
+    fn verify_invalid_auth_token_claims() {
+        //* Given
+        let chain_id = Chain::dev();
+        let contract: Address = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+            .parse()
+            .expect("invalid contract address");
+
+        let wallet =
+            Wallet::from_str("0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d")
+                .expect("invalid private key");
+
+        // Set a different signer address in the claims
+        let signer: Address = "0xf3515b9472fA4bd4a2e4D0B30E9B4a0ab2A68B19"
+            .parse()
+            .expect("invalid signer address");
+
+        let claims = AuthTokenClaims {
+            chain_id,
+            contract,
+            signer,
+            user: None,
+            name: None,
+            allowed_subgraphs: None,
+            allowed_deployments: None,
+            allowed_domains: None,
+        };
+
+        // Encode the auth_token and parse it back.
+        let auth_token = encode_auth_token(&claims, &wallet).expect("failed to encode auth_token");
+        let (claims, signature) =
+            parse_auth_token(&auth_token).expect("failed to parse auth_token");
+
+        //* When
+        let result = verify_auth_token_claims(&claims, &signature);
+
+        //* Then
+        assert_matches!(result, Err(SignatureVerificationError::VerificationError));
+    }
+
+    #[test]
+    fn verify_valid_auth_token_claims() {
+        //* Given
+        let chain_id = Chain::dev();
+        let contract: Address = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+            .parse()
+            .expect("invalid contract address");
+
+        let wallet =
+            Wallet::from_str("0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d")
+                .expect("invalid private key");
+        let wallet_address: Address = wallet.address().as_fixed_bytes().into();
+
+        let claims = AuthTokenClaims {
+            chain_id,
+            contract,
+            signer: wallet_address,
+            user: None,
+            name: None,
+            allowed_subgraphs: None,
+            allowed_deployments: None,
+            allowed_domains: None,
+        };
+
+        // Encode the auth_token and parse it back.
+        let auth_token = encode_auth_token(&claims, &wallet).expect("failed to encode auth_token");
+        let (claims, signature) =
+            parse_auth_token(&auth_token).expect("failed to parse auth_token");
+
+        //* When
+        let result = verify_auth_token_claims(&claims, &signature);
+
+        //* Then
+        assert_matches!(result, Ok(()));
+    }
+}

--- a/thegraph/src/types/attestation.rs
+++ b/thegraph/src/types/attestation.rs
@@ -1,4 +1,3 @@
-pub use alloy_primitives::Address;
 use alloy_primitives::{keccak256, FixedBytes};
 pub use alloy_sol_types::Eip712Domain;
 use alloy_sol_types::SolStruct;
@@ -8,6 +7,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use super::deployment_id::DeploymentId;
+pub use super::primitives::Address;
 use super::primitives::{B256, U256};
 
 lazy_static! {

--- a/thegraph/src/types/primitives.rs
+++ b/thegraph/src/types/primitives.rs
@@ -1,3 +1,3 @@
 //! Re-exported fundamental types
 
-pub use alloy_primitives::{B256, U256};
+pub use alloy_primitives::{Address, B256, U256};


### PR DESCRIPTION
I am currently enhancing the `thegraph` crate to make it compatible with both the edge and node projects, both internally and externally. A crucial element that needs attention is the parsing and generation of Subscription tickets. 

By incorporating the subscription ticket generation, parsing, and validation functionality into the `thegraph` crate, users can seamlessly utilize it alongside the `subgraph_client` for querying any subgraph.