### PR TITLE
chore(toolshed): pin crate git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-http"
+version = "0.1.1"
+source = "git+https://github.com/edgeandnode/toolshed.git?tag=graphql-http-v0.1.1#1eb97feb7b188324529926300135ffe723989c10"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "graphql-introspection-query"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,7 +3227,7 @@ dependencies = [
  "bs58",
  "ethers",
  "ethers-core",
- "graphql-http",
+ "graphql-http 0.1.1 (git+https://github.com/edgeandnode/toolshed.git?tag=graphql-http-v0.1.1)",
  "indoc",
  "lazy_static",
  "reqwest",
@@ -3226,7 +3239,7 @@ dependencies = [
  "test-with",
  "thiserror",
  "tokio",
- "toolshed",
+ "toolshed 0.5.0 (git+https://github.com/edgeandnode/toolshed.git?tag=toolshed-v0.5.0)",
  "tracing",
 ]
 
@@ -3402,6 +3415,15 @@ dependencies = [
 [[package]]
 name = "toolshed"
 version = "0.5.0"
+dependencies = [
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "toolshed"
+version = "0.5.0"
+source = "git+https://github.com/edgeandnode/toolshed.git?tag=toolshed-v0.5.0#211f7d7c4ede10f35b6ebd123a4d3ec8342c9f5e"
 dependencies = [
  "tokio",
  "url",

--- a/thegraph/Cargo.toml
+++ b/thegraph/Cargo.toml
@@ -32,7 +32,7 @@ base64 = { version = "0.21", optional = true }
 bs58 = "0.5"
 ethers = { version = "2.0", default-features = false, optional = true }
 ethers-core = { version = "2.0", default-features = false }
-graphql-http = { path = "../graphql-http", optional = true }
+graphql-http = { git = "https://github.com/edgeandnode/toolshed.git", tag = "graphql-http-v0.1.1", optional = true }
 indoc = { version = "2.0", optional = true }
 lazy_static = "1.4"
 reqwest = { version = "0.11", optional = true }
@@ -42,7 +42,7 @@ serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
 serde_with = "3.4"
 sha3 = "0.10"
 thiserror = "1.0"
-toolshed = { path = "../toolshed", optional = true }
+toolshed = { git = "https://github.com/edgeandnode/toolshed.git", tag = "toolshed-v0.5.0", optional = true }
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
As we are not using a unique version release schema for the crates in this repository, the `path` dependency specifier cannot be used as it can cause dependency version conflicts.

This PR reverts the dependency version specifier changes to use the `git` and `tag` pair. Additionally, it updates the `toolshed` utility crate version to the latest version, v0.5.0.

--- 

From https://github.com/edgeandnode/graph-gateway/pull/478:

> > [!WARNING]
> > Using the latest version (or the `main` branch), probably unstable, is discouraged as it introduces an implicit, uncontrolled, and nontraceable dependency change.
> >
> > It is preferable to use a git tag (or git revision hash) so the version upgrade is traced as part of the development process in the git history, allowing to revert the dependency changes as a quick solution if the upgrade introduced a regression.