### PR TITLE
chore(thegraph-core): add crate placeholder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "thegraph-core"
+version = "0.0.0"
+
+[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 resolver = "2"
 members = [
-    "toolshed",
     "graphql",
     "graphql-http",
-    "thegraph"
+    "thegraph",
+    "thegraph-core",
+    "toolshed",
 ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Edge & Node and contributors.
+Copyright (c) 2024 Edge & Node and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "thegraph-core"
+description = "A collection of Rust modules shared between The Graph's network services"
+version = "0.0.0" # Reserved
+edition = "2021"
+authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
+license = "MIT"
+readme = "README.md"
+
+[dependencies]

--- a/thegraph-core/README.md
+++ b/thegraph-core/README.md
@@ -1,0 +1,31 @@
+thegraph-core
+-------------
+
+[![Crates.io](https://img.shields.io/crates/v/thegraph-core)](https://crates.io/crates/thegraph-core)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](../LICENSE)
+[![ci](https://github.com/edgeandnode/toolshed/actions/workflows/ci.yml/badge.svg)](https://github.com/edgeandnode/toolshed/actions/workflows/ci.yml)
+
+A collection of Rust modules shared between The Graph's network services.
+
+## Usage
+
+To add this crate to your project as a depenency use the `cargo add` command:
+
+```shell
+cargo add thegraph-core
+```
+
+In a cargo workspace use the package selection feature to add it as a dependency
+of a specific package in the workspace:
+
+```shell
+cargo add --package <package-name> thegraph-core 
+```
+
+Alternatively, you can use the `Cargo.toml` file to add the dependency manually
+and point to the git repository's URL and the specific tag you want to use,
+for example:
+
+```toml
+thegraph = { git = "https://github.com/edgeandnode/toolshed.git", tag = "thegraph-core-vX.Y.Z" }
+```

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -1,0 +1,1 @@
+//! A collection of Rust modules that are shared between The Graph's network services.


### PR DESCRIPTION
This PR introduces a placeholder crate module in the repo to gradually migrate to the `<namespace>-*` naming schema to publish the crates in _crates.io_.


> [!NOTE]
> An empty version of the `thegraph-core` crate with version v0.0.0 has been manually published to the _crates.io_ repository. This is a placeholder to reserve the crate name.
>
> The `thegraph` crate name has also been reserved in _crates.io_ for future usage.