### PR TITLE
fix(subgraph_client): avoid panic on missing query block

### DIFF
--- a/thegraph-core/src/client/subgraph_client.rs
+++ b/thegraph-core/src/client/subgraph_client.rs
@@ -43,9 +43,10 @@ async fn send_paginated_query<T: for<'de> Deserialize<'de>>(
 
         let data = match response {
             Ok(data) if !data.results.is_empty() => data,
+            Ok(_) if results.is_empty() => return Err("empty response".into()),
             Ok(_) => break,
             Err(err) => match err {
-                ResponseError::Empty => break,
+                ResponseError::Empty => return Err("empty response".into()),
                 ResponseError::Failure { errors } => {
                     let errors = errors
                         .into_iter()


### PR DESCRIPTION
`send_paginated_query` would panic at `query_block.unwrap()` when the first response is empty.