### PR TITLE
feat(thegraph-core): make subgraph client cloneable

### DIFF
--- a/thegraph-core/tests/it_subgraph_client.rs
+++ b/thegraph-core/tests/it_subgraph_client.rs
@@ -158,7 +158,7 @@ async fn send_subgraph_paginated() {
 
     let http_client = reqwest::Client::new();
 
-    let mut client = SubgraphClient::builder(http_client, subgraph_url)
+    let client = SubgraphClient::builder(http_client, subgraph_url)
         .with_auth_token(Some(auth_token))
         .build();
 


### PR DESCRIPTION
I had to wrap the subgraph client instance with a `Mutex` in the gateway's network module due to the "latest_block" client's internal state. This is causing lock contention and prevents multiple paginated queries from being run concurrently.

Making the internal state atomic and wrapping it in an `Arc` should fix the limitation.