### PR TITLE
fix(thegraph-core): subgraph_client future does not implement Send trait

### DIFF
--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.71.1"
 async-graphql-support = ["dep:async-graphql"]
 subgraph-client = [
     "dep:tracing",
+    "tracing/attributes",
     "dep:indoc",
     "dep:serde_json",
     "dep:reqwest",
@@ -33,7 +34,7 @@ serde_json = { version = "1.0.116", features = ["raw_value"], optional = true }
 serde_with = "3.8"
 thegraph-graphql-http = { version = "0.2", optional = true }
 thiserror = "1.0"
-tracing = { version = "0.1.40", optional = true }
+tracing = { version = "0.1.40", optional = true, default-features = false }
 url = "2.5"
 
 [dev-dependencies]


### PR DESCRIPTION
Using _tracing_'s `Span::entered()` was making the futures not `Send`. 

From [_tracing_ docs](https://docs.rs/tracing/latest/tracing/struct.Span.html#method.entered):

> **Note:** The returned [EnteredSpan](https://docs.rs/tracing/latest/struct.EnteredSpan.html) guard does not implement `Send`. Dropping the guard will exit this span, and if the guard is sent to another thread and dropped there, that thread may never have entered this span. Thus, `EnteredSpans` should not be sent between threads.

