### PR TITLE
fix(thegraph-core): return on empty results response

### DIFF
--- a/thegraph-core/src/client/queries.rs
+++ b/thegraph-core/src/client/queries.rs
@@ -170,6 +170,9 @@ pub mod page {
         pub results: Vec<Box<RawValue>>,
     }
 
+    /// An opaque entry in the response of a subgraph page query.
+    ///
+    /// This is used to determine the ID of the last entity fetched.
     #[derive(Debug, Deserialize)]
     pub struct SubgraphPageQueryResponseOpaqueEntry {
         pub id: String,


### PR DESCRIPTION
Changed the subgraph client behavior from treating an empty paginated query as a special case: The `PaginatedQueryError::EmptyResponse` is no longer returned. Instead, an empty vector is returned.

This PR resolves #229 