### PR TITLE
feat(thegraph-core): add allocation ID and indexer ID new-types

### DIFF
--- a/thegraph-core/src/types.rs
+++ b/thegraph-core/src/types.rs
@@ -1,17 +1,21 @@
 //! The graph network services' foundation types.
 
 // Re-export types in the public API
-pub use alloy_primitives;
+pub use allocation_id::*;
+pub use alloy_primitives::{self, Address};
 pub use alloy_sol_types;
 pub use attestation::*;
 pub use block_pointer::*;
 pub use deployment_id::*;
 pub use ethers_core;
+pub use indexer_id::*;
 pub use poi::*;
 pub use subgraph_id::*;
 
+mod allocation_id;
 pub mod attestation;
 pub mod block_pointer;
 pub mod deployment_id;
+mod indexer_id;
 pub mod poi;
 pub mod subgraph_id;

--- a/thegraph-core/src/types/allocation_id.rs
+++ b/thegraph-core/src/types/allocation_id.rs
@@ -1,0 +1,74 @@
+use alloy_primitives::Address;
+
+/// A unique identifier for an allocation: the allocation's Ethereum address.
+///
+/// This is a "new-type" wrapper around `Address` to provide type safety.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AllocationId(Address);
+
+impl AllocationId {
+    /// Return the internal representation.
+    pub fn into_inner(self) -> Address {
+        self.0
+    }
+}
+
+impl std::fmt::Display for AllocationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::Debug for AllocationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self, f)
+    }
+}
+
+impl From<Address> for AllocationId {
+    fn from(address: Address) -> Self {
+        AllocationId(address)
+    }
+}
+
+impl std::str::FromStr for AllocationId {
+    type Err = <Address as std::str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let address = std::str::FromStr::from_str(s)?;
+        Ok(AllocationId(address))
+    }
+}
+
+impl AsRef<Address> for AllocationId {
+    fn as_ref(&self) -> &Address {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AllocationId {
+    type Target = Address;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AllocationId {
+    fn deserialize<D>(deserializer: D) -> Result<AllocationId, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let address = Address::deserialize(deserializer)?;
+        Ok(AllocationId(address))
+    }
+}
+
+impl serde::Serialize for AllocationId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}

--- a/thegraph-core/src/types/indexer_id.rs
+++ b/thegraph-core/src/types/indexer_id.rs
@@ -1,0 +1,74 @@
+use alloy_primitives::Address;
+
+/// A unique identifier for an indexer: the indexer's Ethereum address.
+///
+/// This is a "new-type" wrapper around `Address` to provide type safety.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct IndexerId(Address);
+
+impl IndexerId {
+    /// Return the internal representation.
+    pub fn into_inner(self) -> Address {
+        self.0
+    }
+}
+
+impl std::fmt::Display for IndexerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::Debug for IndexerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self, f)
+    }
+}
+
+impl From<Address> for IndexerId {
+    fn from(address: Address) -> Self {
+        IndexerId(address)
+    }
+}
+
+impl std::str::FromStr for IndexerId {
+    type Err = <Address as std::str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let address = std::str::FromStr::from_str(s)?;
+        Ok(IndexerId(address))
+    }
+}
+
+impl AsRef<Address> for IndexerId {
+    fn as_ref(&self) -> &Address {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for IndexerId {
+    type Target = Address;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for IndexerId {
+    fn deserialize<D>(deserializer: D) -> Result<IndexerId, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let address = Address::deserialize(deserializer)?;
+        Ok(IndexerId(address))
+    }
+}
+
+impl serde::Serialize for IndexerId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}


### PR DESCRIPTION
When interacting with the https://github.com/graphprotocol/graph-network-subgraph, important entities such as an indexer or an allocation are uniquely identifiable by their Ethereum address. We are using extensively the `alloy_primitives::Address` type to represent this `id` entity field.

By wrapping the `Address` type in a "new-type wrapper" type, we can leverage Rust's type system to get type guarantees across the codebase. This makes the code more readable and removes the possibility of misusing the APIs.