### PR TITLE
fix(thegraph-core): fix allocation and indexer ID fmt implementations

### DIFF
--- a/thegraph-core/src/types/allocation_id.rs
+++ b/thegraph-core/src/types/allocation_id.rs
@@ -3,6 +3,18 @@ use alloy_primitives::Address;
 /// A unique identifier for an allocation: the allocation's Ethereum address.
 ///
 /// This is a "new-type" wrapper around [`Address`] to provide type safety.
+///
+/// ## Formatting
+///
+/// The `AllocationId` type implements the following formatting traits:
+///
+/// - Use [`Display`] for formatting the `AllocationId` as an [EIP-55] checksum string.
+/// - Use [`LowerHex`] (or [`UpperHex`]) for formatting the `AllocationId` as a hexadecimal string.
+///
+/// [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
+/// [`Display`]: struct.AllocationId.html#impl-Display-for-AllocationId
+/// [`LowerHex`]: struct.AllocationId.html#impl-LowerHex-for-AllocationId
+/// [`UpperHex`]: struct.AllocationId.html#impl-UpperHex-for-AllocationId
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocationId(Address);
 
@@ -19,14 +31,95 @@ impl AllocationId {
 }
 
 impl std::fmt::Display for AllocationId {
+    /// Formats the `AllocationId` using its [EIP-55](https://eips.ethereum.org/EIPS/eip-55)
+    /// checksum representation.
+    ///
+    /// See [`LowerHex`] (and [`UpperHex`]) for formatting the `AllocationId` as a hexadecimal
+    /// string.
+    ///
+    /// [`LowerHex`]: struct.AllocationId.html#impl-LowerHex-for-AllocationId
+    /// [`UpperHex`]: struct.AllocationId.html#impl-UpperHex-for-AllocationId
+    ///
+    /// ```rust
+    /// use thegraph_core::allocation_id;
+    /// use thegraph_core::types::AllocationId;
+    ///
+    /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Note the uppercase and lowercase hex characters in the checksum
+    /// assert_eq!(format!("{}", ID), "0x0002c67268FB8C8917F36F865a0CbdF5292FA68d");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl std::fmt::Debug for AllocationId {
+    /// Formats the `AllocationId` using its raw lower-case hexadecimal representation.
+    ///
+    /// It is advised to use the [`LowerHex`] (and [`UpperHex`]) format trait implementation over
+    /// the [`Debug`](std::fmt::Debug) implementation to format the `AllocationId` as a lower-case
+    /// hexadecimal string.
+    ///
+    /// This implementation matches `alloy_primitives::Address`'s `Debug` implementation.
+    ///
+    /// [`LowerHex`]: struct.AllocationId.html#impl-LowerHex-for-AllocationId
+    /// [`UpperHex`]: struct.AllocationId.html#impl-UpperHex-for-AllocationId
+    ///
+    /// ```rust
+    /// use thegraph_core::allocation_id;
+    /// use thegraph_core::types::AllocationId;
+    ///
+    /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// assert_eq!(format!("{:?}", ID), "0x0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self, f)
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::LowerHex for AllocationId {
+    /// Lowercase hex representation of the `AllocationId`.
+    ///
+    /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
+    ///
+    /// ```rust
+    /// use thegraph_core::allocation_id;
+    /// use thegraph_core::types::AllocationId;
+    ///
+    /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Lower hex
+    /// assert_eq!(format!("{:x}", ID), "0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Lower hex with alternate flag
+    /// assert_eq!(format!("{:#x}", ID), "0x0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::UpperHex for AllocationId {
+    /// Uppercase hex representation of the `AllocationId`.
+    ///
+    /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
+    ///
+    /// ```rust
+    /// use thegraph_core::allocation_id;
+    /// use thegraph_core::types::AllocationId;
+    ///
+    /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Upper hex
+    /// assert_eq!(format!("{:X}", ID), "0002C67268FB8C8917F36F865A0CBDF5292FA68D");
+    ///
+    /// // Upper hex with alternate flag
+    /// assert_eq!(format!("{:#X}", ID), "0x0002C67268FB8C8917F36F865A0CBDF5292FA68D");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::UpperHex::fmt(&self.0, f)
     }
 }
 
@@ -93,7 +186,7 @@ impl serde::Serialize for AllocationId {
 ///
 /// ```rust
 /// use thegraph_core::allocation_id;
-/// use thegraph_core::types::{AllocationId };
+/// use thegraph_core::types::AllocationId;
 ///
 /// const ALLOCATION_ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
 /// ```

--- a/thegraph-core/src/types/deployment_id.rs
+++ b/thegraph-core/src/types/deployment_id.rs
@@ -99,19 +99,63 @@ impl std::str::FromStr for DeploymentId {
 }
 
 impl std::fmt::Display for DeploymentId {
-    /// Encode the deployment ID as CIDv0 (base58-encoded sha256-hash).
+    /// Format the `DeploymentId` as CIDv0 (base58-encoded sha256-hash) string.
+    ///
+    /// ```rust
+    /// use thegraph_core::deployment_id;
+    /// use thegraph_core::types::DeploymentId;
+    ///
+    /// const ID: DeploymentId = deployment_id!("QmSWxvd8SaQK6qZKJ7xtfxCCGoRzGnoi2WNzmJYYJW9BXY");
+    ///
+    /// assert_eq!(format!("{}", ID), "QmSWxvd8SaQK6qZKJ7xtfxCCGoRzGnoi2WNzmJYYJW9BXY");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&format_cid_v0(self.0.as_slice()))
     }
 }
 
 impl std::fmt::Debug for DeploymentId {
+    /// Format the `DeploymentId` as a debug string.
+    ///
+    /// ```rust
+    /// use thegraph_core::deployment_id;
+    /// use thegraph_core::types::DeploymentId;
+    ///
+    /// const ID: DeploymentId = deployment_id!("QmSWxvd8SaQK6qZKJ7xtfxCCGoRzGnoi2WNzmJYYJW9BXY");
+    ///
+    /// assert_eq!(
+    ///     format!("{:?}", ID),
+    ///     "DeploymentId(QmSWxvd8SaQK6qZKJ7xtfxCCGoRzGnoi2WNzmJYYJW9BXY)",
+    /// );
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "DeploymentId({})", self)
     }
 }
 
 impl std::fmt::LowerHex for DeploymentId {
+    /// Format the `DeploymentId` as a 32-byte hex string.
+    ///
+    /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
+    ///
+    /// ```rust
+    /// use thegraph_core::deployment_id;
+    /// use thegraph_core::types::DeploymentId;
+    ///
+    /// const ID: DeploymentId = deployment_id!("QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz");
+    ///
+    /// // Lower hex
+    /// assert_eq!(
+    ///     format!("{:x}", ID),
+    ///     "7d5a99f603f231d53a4f39d1521f98d2e8bb279cf29bebfd0687dc98458e7f89"
+    /// );
+    ///
+    /// // Lower hex with alternate flag
+    /// assert_eq!(
+    ///     format!("{:#x}", ID),
+    ///     "0x7d5a99f603f231d53a4f39d1521f98d2e8bb279cf29bebfd0687dc98458e7f89"
+    /// );
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::LowerHex::fmt(&self.0, f)
     }

--- a/thegraph-core/src/types/indexer_id.rs
+++ b/thegraph-core/src/types/indexer_id.rs
@@ -3,6 +3,18 @@ use alloy_primitives::Address;
 /// A unique identifier for an indexer: the indexer's Ethereum address.
 ///
 /// This is a "new-type" wrapper around [`Address`] to provide type safety.
+///
+/// ## Formatting
+///
+/// The `IndexerId` type implements the following formatting traits:
+///
+/// - Use [`Display`] for formatting the `IndexerId` as an [EIP-55] checksum string.
+/// - Use [`LowerHex`] (or [`UpperHex`]) for formatting the `IndexerId` as a hexadecimal string.
+///
+/// [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
+/// [`Display`]: struct.IndexerId.html#impl-Display-for-IndexerId
+/// [`LowerHex`]: struct.IndexerId.html#impl-LowerHex-for-IndexerId
+/// [`UpperHex`]: struct.IndexerId.html#impl-UpperHex-for-IndexerId
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndexerId(Address);
 
@@ -19,14 +31,95 @@ impl IndexerId {
 }
 
 impl std::fmt::Display for IndexerId {
+    /// Formats the `IndexerId` using its [EIP-55](https://eips.ethereum.org/EIPS/eip-55)
+    /// checksum representation.
+    ///
+    /// See [`LowerHex`] (and [`UpperHex`]) for formatting the `IndexerId` as a hexadecimal
+    /// string.
+    ///
+    /// [`LowerHex`]: struct.IndexerId.html#impl-LowerHex-for-IndexerId
+    /// [`UpperHex`]: struct.IndexerId.html#impl-UpperHex-for-IndexerId
+    ///
+    /// ```rust
+    /// use thegraph_core::indexer_id;
+    /// use thegraph_core::types::IndexerId;
+    ///
+    /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Note the uppercase and lowercase hex characters in the checksum
+    /// assert_eq!(format!("{}", ID), "0x0002c67268FB8C8917F36F865a0CbdF5292FA68d");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl std::fmt::Debug for IndexerId {
+    /// Formats the `IndexerId` using its raw lower-case hexadecimal representation.
+    ///
+    /// It is advised to use the [`LowerHex`] (and [`UpperHex`]) format trait implementation over
+    /// the [`Debug`](std::fmt::Debug) implementation to format the `IndexerId` as a lower-case
+    /// hexadecimal string.
+    ///
+    /// This implementation matches `alloy_primitives::Address`'s `Debug` implementation.
+    ///
+    /// [`LowerHex`]: struct.IndexerId.html#impl-LowerHex-for-IndexerId
+    /// [`UpperHex`]: struct.IndexerId.html#impl-UpperHex-for-IndexerId
+    ///
+    /// ```rust
+    /// use thegraph_core::indexer_id;
+    /// use thegraph_core::types::IndexerId;
+    ///
+    /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// assert_eq!(format!("{:?}", ID), "0x0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self, f)
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::LowerHex for IndexerId {
+    /// Lowercase hex representation of the `IndexerId`.
+    ///
+    /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
+    ///
+    /// ```rust
+    /// use thegraph_core::indexer_id;
+    /// use thegraph_core::types::IndexerId;
+    ///
+    /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Lower hex
+    /// assert_eq!(format!("{:x}", ID), "0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Lower hex with alternate flag
+    /// assert_eq!(format!("{:#x}", ID), "0x0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::UpperHex for IndexerId {
+    /// Uppercase hex representation of the `IndexerId`.
+    ///
+    /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
+    ///
+    /// ```rust
+    /// use thegraph_core::indexer_id;
+    /// use thegraph_core::types::IndexerId;
+    ///
+    /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
+    ///
+    /// // Upper hex
+    /// assert_eq!(format!("{:X}", ID), "0002C67268FB8C8917F36F865A0CBDF5292FA68D");
+    ///
+    /// // Upper hex with alternate flag
+    /// assert_eq!(format!("{:#X}", ID), "0x0002C67268FB8C8917F36F865A0CBDF5292FA68D");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::UpperHex::fmt(&self.0, f)
     }
 }
 

--- a/thegraph-core/src/types/subgraph_id.rs
+++ b/thegraph-core/src/types/subgraph_id.rs
@@ -56,7 +56,7 @@ impl AsRef<B256> for SubgraphId {
 impl std::str::FromStr for SubgraphId {
     type Err = &'static str;
 
-    /// Attempt to parse a Subgraph ID in v2 format: `base58(sha256(<subgraph_id>))`
+    /// Parse a `SubgraphID` from a base-58 encoded string.
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let mut buffer = [0_u8; 32];
 
@@ -76,14 +76,34 @@ impl std::str::FromStr for SubgraphId {
 }
 
 impl std::fmt::Display for SubgraphId {
+    /// Format the `SubgraphId` as a base58-encoded string.
+    ///
+    /// ```rust
+    /// use thegraph_core::subgraph_id;
+    /// use thegraph_core::types::SubgraphId;
+    ///
+    /// const ID: SubgraphId = subgraph_id!("DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
+    ///
+    /// assert_eq!(format!("{}", ID), "DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&bs58::encode(self.0.as_slice()).into_string())
     }
 }
 
 impl std::fmt::Debug for SubgraphId {
+    /// Format the `SubgraphId` as a debug string.
+    ///
+    /// ```rust
+    /// use thegraph_core::subgraph_id;
+    /// use thegraph_core::types::SubgraphId;
+    ///
+    /// const ID: SubgraphId = subgraph_id!("DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
+    ///
+    /// assert_eq!(format!("{:?}", ID), "SubgraphId(DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp)");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Subgraph({})", self)
+        write!(f, "SubgraphId({})", self)
     }
 }
 
@@ -183,7 +203,7 @@ mod tests {
     #[test]
     fn format_subgraph_id_debug() {
         //* Given
-        let expected_debug_repr = format!("Subgraph({})", VALID_SUBGRAPH_ID);
+        let expected_debug_repr = format!("SubgraphId({})", VALID_SUBGRAPH_ID);
 
         let valid_id = EXPECTED_ID;
 


### PR DESCRIPTION
In this PR:

- [x] Align the `std::fmt::Debug` implementation of the `AllocationId` and `IndexerId` types with the underlying `alloy_primitives::Address` type's debug trait implementation. 
- [x] Add the `std::fmt::LowerHex` and `std::fmt::Upperhex` trait implementations for these two ID types. These formatting methods should be used (instead of the `Debug` method) to get the hex representation of the underlying address for explicitness.
- [x] Improve the types' documentation and add examples (doc tests) covering the formatting traits.

This PR supersedes #271 