### PR TITLE
feat(thegraph-core): add EIP-712 signed message module

### DIFF
--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -21,6 +21,7 @@ alloy-sol-types = ["alloy/sol-types"]
 async-graphql = ["dep:async-graphql"]
 fake = ["dep:fake"]
 serde = ["dep:serde", "dep:serde_with", "alloy/serde"]
+signed-message = ["alloy-eip712", "alloy-signers", "alloy-sol-types"]
 
 [dependencies]
 alloy = "0.7"

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -24,6 +24,8 @@
 //! - `async-graphql`: Enables support for the [`async-graphql`] crate.
 //! - `fake`: Enables the [`fake`] crate integration for generating random test data.
 //! - `serde`: Enables [`serde`] serialization and deserialization support for types in this crate.
+//! - `signed-message`: Enables the `signed_message` module, which provides types and functions for
+//!                     EIP-712 message signing and verification.
 //!
 //! Additionally, this crate re-exports other features from the `alloy` crate as described above.
 
@@ -51,6 +53,9 @@ mod block;
 mod deployment_id;
 mod indexer_id;
 mod proof_of_indexing;
+#[cfg(feature = "signed-message")]
+#[cfg_attr(docsrs, doc(cfg(feature = "signed-message")))]
+pub mod signed_message;
 mod subgraph_id;
 
 // Export macros

--- a/thegraph-core/src/signed_message.rs
+++ b/thegraph-core/src/signed_message.rs
@@ -1,0 +1,247 @@
+//! EIP-712 message signing and verification.
+//!
+//! This module provides the [`SignedMessage`] struct for signing and verifying messages according
+//! to the [EIP-712] standard.
+//!
+//! Available functions for interacting with messages:
+//!
+//! - [`sign`]: Signs a message using the EIP-712 standard.
+//! - [`recover_signer_address`]: Recovers the signer's address from a signed message.
+//! - [`verify`]: Convenience wrapper over [`recover_signer_address`] to verify the signer's
+//!   address.
+//!
+//! To use a Rust struct as a message, it must implement the [`ToSolStruct`] trait.
+//! Refer to the example below for more details.
+//!
+//! ## Example
+//! ```rust
+//! # use thegraph_core::alloy::{
+//! #    primitives::{Address, B256, address, b256, keccak256},
+//! #    sol_types::{eip712_domain, Eip712Domain},
+//! # };
+//! use thegraph_core::signed_message::{sign, verify, ToSolStruct};
+//!
+//! // Create a signer instance
+//! let signer = thegraph_core::alloy::signers::local::PrivateKeySigner::random();
+//!
+//! // Define the EIP-712 domain separator
+//! const DOMAIN: Eip712Domain = eip712_domain! {
+//!      name: "Example domain",
+//!      version: "1",
+//!      chain_id: 1,
+//!      verifying_contract: address!("a83682bbe91c0d2d48a13fd751b2da8e989fe421"),
+//!      salt: b256!("66eb090e6dbb9668c7d32c0ee7ba5e8f08d84385804485d316dd5f5692273593"),
+//! };
+//!
+//! // Define a message struct
+//! #[derive(Clone, Debug)]
+//! struct Message {
+//!    addr: Address,
+//!    hash: [u8; 32],
+//! }
+//!
+//! // Define the message equivalent solidity struct
+//! thegraph_core::alloy::sol! {
+//!     struct MessageSol {
+//!         address addr;
+//!         bytes32 hash;
+//!     }
+//! }
+//!
+//! // Implement the ToSolStruct trait for the message struct
+//! impl ToSolStruct<MessageSol> for Message {
+//!     fn to_sol_struct(&self) -> MessageSol {
+//!         MessageSol {
+//!            addr: self.addr,
+//!            hash: self.hash.into(),
+//!        }
+//!     }
+//! }
+//!
+//! // Create a message instance with some data
+//! let message = Message {
+//!    addr: address!("03f6d2a3d8c3413de72c193386f1894e1ddc2b6b"),
+//!    hash: *keccak256(b"Hello, world!"),
+//! };
+//!
+//! // Sign the message
+//! let signed_message = sign(&signer, &DOMAIN, message).expect("sign_message failed");
+//!
+//! // Verify the signed message
+//! assert!(verify(&DOMAIN, &signed_message, &signer.address()).is_ok());
+//! ```
+//!
+//! [EIP-712]: https://eips.ethereum.org/EIPS/eip-712 "EIP-712"
+
+mod message;
+mod signing;
+
+pub use message::{SignedMessage, ToSolStruct};
+pub use signing::{
+    recover_signer_address, sign, verify, RecoverSignerError, SigningError, VerificationError,
+};
+
+#[cfg(test)]
+mod tests {
+    use alloy::{
+        primitives::{address, b256, keccak256, PrimitiveSignature as Signature},
+        signers::local::PrivateKeySigner,
+        sol_types::{eip712_domain, Eip712Domain},
+    };
+
+    use super::{message::SignedMessage, signing, signing::VerificationError};
+
+    /// Test EIP712 domain separator
+    const EIP712_DOMAIN: Eip712Domain = eip712_domain! {
+        name: "Test domain",
+        version: "1",
+        chain_id: 1,
+        verifying_contract: address!("a83682bbe91c0d2d48a13fd751b2da8e989fe421"),
+        salt: b256!("66eb090e6dbb9668c7d32c0ee7ba5e8f08d84385804485d316dd5f5692273593")
+    };
+
+    alloy::sol! {
+        /// Test struct for EIP712 message
+        struct Message {
+            bytes32 data;
+        }
+    }
+
+    /// Test utility method generating a random wallet
+    fn wallet() -> PrivateKeySigner {
+        PrivateKeySigner::random()
+    }
+
+    #[test]
+    fn sign_message_with_private_key_signer() {
+        //* Given
+        let signer = wallet();
+        let domain = EIP712_DOMAIN;
+
+        // Create a message with some data
+        let message = Message {
+            data: keccak256(b"Hello, world!"),
+        };
+
+        //* When
+        // Sign the message
+        let result = signing::sign(&signer, &domain, message);
+
+        //* Then
+        // The message should be signed
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn recover_signer_from_signed_message() {
+        //* Given
+        let signer = wallet();
+
+        let domain = EIP712_DOMAIN;
+
+        // Create a message with some data
+        let message = Message {
+            data: keccak256(b"Hello, world!"),
+        };
+
+        // Sign the message
+        let signed_message = signing::sign(&signer, &domain, message).unwrap();
+
+        //* When
+        // Recover the signer's address
+        let result = signing::recover_signer_address(&domain, &signed_message);
+
+        //* Then
+        // The address should be recovered
+        let signer_address = result.expect("recover_signer failed");
+
+        // The signer should be the wallet's address
+        assert_eq!(signer_address, signer_address);
+    }
+
+    #[test]
+    fn recover_signer_should_fail_with_invalid_signature() {
+        //* Given
+        let domain = EIP712_DOMAIN;
+
+        // Create a message with some data
+        let message = Message {
+            data: keccak256(b"Hello, world!"),
+        };
+
+        // Create a signed message with an invalid signature (random values)
+        let invalid_signature_signed_message = SignedMessage {
+            message,
+            signature: Signature::from_scalars_and_parity(
+                b256!("ca457b3f821e5c03545944e0318868a783d0e6b438c85a82537d52a619decfe2"),
+                b256!("26a9f36fcf89431476aa556021ee77959dc480fb3458054f26d068b52d525cc4"),
+                false,
+            ),
+        };
+
+        //* When
+        // Recover the signer's address
+        let result = signing::recover_signer_address(&domain, &invalid_signature_signed_message);
+
+        //* Then
+        // The address should not be recovered
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_signed_message() {
+        //* Given
+        let signer = wallet();
+        let signer_address = signer.address();
+
+        let domain = EIP712_DOMAIN;
+
+        let message = Message {
+            data: keccak256(b"Hello, world!"),
+        };
+
+        // Sign the message
+        let signed_message = signing::sign(&signer, &domain, message).unwrap();
+
+        //* When
+        // Verify the signed message
+        let result = signing::verify(&domain, &signed_message, &signer_address);
+
+        //* Then
+        // The signature should be valid
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn signed_message_verification_should_fail_with_invalid_signer() {
+        //* Given
+        let signer = wallet();
+        let domain = EIP712_DOMAIN;
+
+        // Create a message with some data
+        let message = Message {
+            data: keccak256(b"Hello, world!"),
+        };
+
+        // Sign the message
+        let signed_message = signing::sign(&signer, &domain, message).unwrap();
+
+        // Create a different signer
+        let different_signer = wallet();
+        let different_signer_address = different_signer.address();
+
+        //* When
+        // Verify the signed message
+        let result = signing::verify(&domain, &signed_message, &different_signer_address);
+
+        //* Then
+        // The signature should be invalid
+        let error = result.expect_err("verify_signature should fail");
+        if let VerificationError::InvalidSigner { expected, received } = error {
+            assert_eq!(expected, different_signer_address);
+            assert_eq!(received, signer.address());
+        } else {
+            panic!("unexpected error: {:?}", error);
+        }
+    }
+}

--- a/thegraph-core/src/signed_message/message.rs
+++ b/thegraph-core/src/signed_message/message.rs
@@ -1,0 +1,106 @@
+use alloy::{primitives::PrimitiveSignature as Signature, sol_types::SolStruct};
+
+/// EIP-712 signed message
+///
+/// This struct contains a message and the ECDSA signature of the message according to the
+/// EIP-712 standard.
+///
+/// For the message to be signed, it must either:
+/// - To be a _Solidity struct_, i.e., implement the `SolStruct` trait.
+/// - To be convertible into a _Solidity struct_, i.e., implement the `ToSolStruct` trait.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedMessage<M> {
+    /// Message payload
+    pub message: M,
+    /// ECDSA message signature
+    pub signature: Signature,
+}
+
+impl<M> SignedMessage<M> {
+    /// Get the EIP-712 signature bytes.
+    ///
+    /// The ECDSA signature bytes can be used as a key in a [`BTreeMap`] (or [`HashMap`]) to
+    /// deduplicate signed messages based on their signature.
+    ///
+    /// [`BTreeMap`]: std::collections::BTreeMap
+    /// [`HashMap`]: std::collections::HashMap
+    pub fn signature_bytes(&self) -> SignatureBytes {
+        SignatureBytes(self.signature.as_bytes())
+    }
+
+    /// Hash the message struct according to [EIP-712 `hashStruct`](https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct).
+    ///
+    /// The resulting hash can be used to deduplicate messages. As the hash does not include the
+    /// signature, it is unique for a given message payload. This means that two [`SignedMessage`]s,
+    /// signed by two different signers, will have the same hash.
+    pub fn message_hash<MSol>(&self) -> MessageHash
+    where
+        M: ToSolStruct<MSol>,
+        MSol: SolStruct,
+    {
+        MessageHash(*self.message.to_sol_struct().eip712_hash_struct())
+    }
+}
+
+/// The EIP-712 ECDSA signature bytes.
+///
+/// See: [`SignedMessage::signature_bytes`]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SignatureBytes([u8; 65]);
+
+impl SignatureBytes {
+    /// Get the signature bytes
+    pub fn as_bytes(&self) -> [u8; 65] {
+        self.0
+    }
+}
+
+impl std::ops::Deref for SignatureBytes {
+    type Target = [u8; 65];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Message hash according to [EIP-712 `hashStruct`](https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct).
+///
+/// See: [`SignedMessage::message_hash`]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MessageHash([u8; 32]);
+
+impl MessageHash {
+    /// Get the message hash bytes
+    pub fn as_bytes(&self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl std::ops::Deref for MessageHash {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A conversion trait for converting a type into a solidity struct representation
+///
+/// This trait is used to convert a Rust type into a struct implementing the `SolStruct` trait.
+pub trait ToSolStruct<T: SolStruct> {
+    /// Convert into the solidity struct representation
+    fn to_sol_struct(&self) -> T;
+}
+
+impl<T> ToSolStruct<T> for T
+where
+    T: SolStruct + Clone,
+{
+    /// Convert into the solidity struct representation.
+    ///
+    /// If the type already implements the `SolStruct` trait, this method will return a clone of
+    /// the type without performing any conversion.
+    fn to_sol_struct(&self) -> T {
+        self.clone()
+    }
+}

--- a/thegraph-core/src/signed_message/signing.rs
+++ b/thegraph-core/src/signed_message/signing.rs
@@ -1,0 +1,133 @@
+use alloy::{
+    primitives::{Address, SignatureError},
+    signers::{
+        k256::ecdsa::Error as EcdsaError, Error as SignerError, SignerSync,
+        UnsupportedSignerOperation,
+    },
+    sol_types::{Eip712Domain, SolStruct},
+};
+
+use super::message::{SignedMessage, ToSolStruct};
+
+/// Errors that can occur when signing a message.
+#[derive(Debug, thiserror::Error)]
+pub enum SigningError {
+    /// The signer does not support the operation
+    #[error("operation `{0}` is not supported by the signer")]
+    UnsupportedOperation(UnsupportedSignerOperation),
+
+    /// The ECDSA signature failed
+    #[error(transparent)]
+    Ecdsa(#[from] EcdsaError),
+
+    /// Generic error
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+/// Errors that can occur when recovering the signer's address of a message.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct RecoverSignerError(#[from] SignatureError);
+
+/// Errors that can occur when verifying the signer's address of a message.
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    /// Errors in signature parsing or verification
+    #[error(transparent)]
+    SignatureError(#[from] SignatureError),
+
+    /// The signer's address does not match the expected address
+    #[error("expected signer `{expected}` but received `{received}`")]
+    InvalidSigner {
+        /// The expected signer's address
+        expected: Address,
+        /// The received signer's address
+        received: Address,
+    },
+}
+
+/// Signs a message using the [EIP-712] standard
+///
+/// Returns a [`SignedMessage`] containing the message and the ECDSA signature of the message
+///
+/// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712 "EIP-712"
+pub fn sign<S, M, MSol>(
+    signer: &S,
+    domain: &Eip712Domain,
+    message: M,
+) -> Result<SignedMessage<M>, SigningError>
+where
+    S: SignerSync,
+    M: ToSolStruct<MSol>,
+    MSol: SolStruct,
+{
+    let message_sol = message.to_sol_struct();
+    let signature = signer
+        .sign_typed_data_sync(&message_sol, domain)
+        .map_err(|err| match err {
+            SignerError::UnsupportedOperation(err) => SigningError::UnsupportedOperation(err),
+            SignerError::TransactionChainIdMismatch { .. } => {
+                unreachable!("sign_typed_data_sync should not return TransactionChainIdMismatch")
+            }
+            SignerError::DynAbiError(_) => {
+                unreachable!("sign_typed_data_sync should not return DynAbiError")
+            }
+            SignerError::Ecdsa(err) => SigningError::Ecdsa(err),
+            SignerError::HexError(_) => {
+                unreachable!("sign_typed_data_sync should not return HexError")
+            }
+            SignerError::SignatureError(_) => {
+                unreachable!("sign_typed_data_sync should not return SignatureError")
+            }
+            SignerError::Other(err) => SigningError::Other(err),
+        })?;
+    Ok(SignedMessage { message, signature })
+}
+
+/// Recover the signer's address  an [EIP-712] signed message
+///
+/// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712 "EIP-712"
+pub fn recover_signer_address<M, MSol>(
+    domain: &Eip712Domain,
+    signed_message: &SignedMessage<M>,
+) -> Result<Address, RecoverSignerError>
+where
+    M: ToSolStruct<MSol>,
+    MSol: SolStruct,
+{
+    let message_sol = signed_message.message.to_sol_struct();
+    let recovery_message_hash = message_sol.eip712_signing_hash(domain);
+    let recovered_address = signed_message
+        .signature
+        .recover_address_from_prehash(&recovery_message_hash)?;
+    Ok(recovered_address)
+}
+
+/// Verify the signer's address of an [EIP-712] signed message
+///
+/// Returns `Ok(())` if the  signer's address retrieved from the signature matches the expected
+/// address. Otherwise, returns a [`VerificationError`] with details about the mismatch.
+///
+/// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712 "EIP-712"
+pub fn verify<M, MSol>(
+    domain: &Eip712Domain,
+    signed_message: &SignedMessage<M>,
+    expected_address: &Address,
+) -> Result<(), VerificationError>
+where
+    M: ToSolStruct<MSol>,
+    MSol: SolStruct,
+{
+    let recovered_address =
+        recover_signer_address(domain, signed_message).map_err(|RecoverSignerError(err)| err)?;
+
+    if recovered_address != *expected_address {
+        Err(VerificationError::InvalidSigner {
+            expected: expected_address.to_owned(),
+            received: recovered_address,
+        })
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This pull request introduces a new EIP-712 message signing and verification feature in the `thegraph-core` package. The most significant changes include adding a new module for signed messages, updating the `Cargo.toml` file to include new dependencies, and providing comprehensive tests for this new functionality.

### New Feature: EIP-712 Message Signing and Verification

* **New Feature**: Added `signed-message` to the crate features list.
* **New Module**: Introduced a new module `signed_message` in `thegraph-core/src/lib.rs` with conditional compilation based on the `signed-message` feature.
* **Signed Message Implementation**: Created the `SignedMessage` struct and related functionality in `thegraph-core/src/signed_message.rs`, including signing, verifying, and recovering signer addresses.
* **Message Struct and Traits**: Defined the `SignedMessage` struct and `ToSolStruct` trait in `thegraph-core/src/signed_message/message.rs` for handling EIP-712 signed messages.
* **Signing and Verification Functions**: Implemented the `sign`, `verify`, and `recover_signer_address` functions in `thegraph-core/src/signed_message/signing.rs` to facilitate EIP-712 message signing and verification.