### PR TITLE
fix(thegraph-core): remove explicit dependency on alloy-sol-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,7 +4127,6 @@ name = "thegraph-core"
 version = "0.8.1"
 dependencies = [
  "alloy",
- "alloy-sol-types",
  "assert_matches",
  "async-graphql",
  "bs58",

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -26,7 +26,6 @@ subgraph-client = [
 
 [dependencies]
 alloy = { version = "0.6", features = ["eip712", "signers", "sol-types"] }
-alloy-sol-types = "0.8"
 async-graphql = { version = "7.0", optional = true }
 bs58 = "0.5"
 indoc = { version = "2.0.5", optional = true }

--- a/thegraph-core/src/attestation.rs
+++ b/thegraph-core/src/attestation.rs
@@ -42,7 +42,7 @@ pub struct Attestation {
     pub v: u8,
 }
 
-alloy::sol_types::sol! {
+alloy::sol! {
     /// EIP-712 receipt struct for attestation signing.
     struct Receipt {
         bytes32 requestCID;


### PR DESCRIPTION
As one can see in the alloy book, the `sol!` macro must be imported as `use alloy::sol;` to avoid the following error:

```
error[E0432]: unresolved import `alloy_sol_types`
  --> thegraph-core/src/attestation.rs:45:1
   |
45 | / alloy::sol_types::sol! {
46 | |     /// EIP-712 receipt struct for attestation signing.
47 | |     struct Receipt {
48 | |         bytes32 requestCID;
...  |
51 | |     }
52 | | }
   | |_^ no external crate `alloy_sol_types`
   |
   = note: this error originates in the macro `alloy::sol_types::sol` (in Nightly builds, run with -Z macro-backtrace for more info)
```

See: https://alloy.rs/highlights/the-sol!-procedural-macro.html