### PR TITLE
revert(thegraph-core): gate the attestation module behind a crate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,7 +3407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -3477,7 +3477,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -9,15 +9,11 @@ edition = "2021"
 rust-version = "1.79.0"
 
 [features]
-default = ["attestation"]
-attestation = ["alloy-eip712", "alloy-signers", "alloy-sol-types"]
+default = []
 alloy-contract = ["alloy/contract"]
-alloy-eip712 = ["alloy/eip712"]
 alloy-full = ["alloy/full"]
 alloy-rlp = ["alloy/rlp"]
 alloy-signer-local = ["alloy/signer-local"]
-alloy-signers = ["alloy/signers"]
-alloy-sol-types = ["alloy/sol-types"]
 async-graphql-support = ["dep:async-graphql"]
 serde = ["dep:serde", "dep:serde_with", "alloy/serde"]
 subgraph-client = [
@@ -32,7 +28,7 @@ subgraph-client = [
 ]
 
 [dependencies]
-alloy = "0.6"
+alloy = { version = "0.6", features = ["eip712", "signers", "sol-types"] }
 async-graphql = { version = "7.0", optional = true }
 bs58 = "0.5"
 indoc = { version = "2.0.5", optional = true }

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -14,12 +14,10 @@
 // Re-export `alloy` crate
 pub use alloy;
 
-#[cfg(feature = "attestation")]
-#[cfg_attr(feature = "attestation", doc(hidden))]
-pub use self::attestation::Attestation;
 #[doc(inline)]
 pub use self::{
     allocation_id::AllocationId,
+    attestation::Attestation,
     block::BlockPointer,
     deployment_id::{DeploymentId, ParseDeploymentIdError},
     indexer_id::IndexerId,
@@ -28,8 +26,6 @@ pub use self::{
 };
 
 mod allocation_id;
-#[cfg(feature = "attestation")]
-#[cfg_attr(docsrs, doc(cfg(feature = "attestation")))]
 pub mod attestation;
 mod block;
 #[deprecated(


### PR DESCRIPTION
This reverts commit 3fa5b3edcfe30bd62ff5538e4e10398475988fd9 as cargo semver-checks treats this as a breaking change:

```
--- failure struct_now_doc_hidden: pub struct is now #[doc(hidden)] ---

Description:
A pub struct is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_now_doc_hidden.ron

Failed in:
  struct Attestation in file /tmp/.tmpGBz2Xn/toolshed/thegraph-core/src/attestation.rs:27
```  
  