### PR TITLE
chore(ci): change marcoieni/release-plz-action to release-plz/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
-      - uses: MarcoIeni/release-plz-action@2d634174257b7f46339e7533865a910743a0c5c9 # v0.5
+      - uses: release-plz/action@2d634174257b7f46339e7533865a910743a0c5c9 # v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The change updates the action used for releases to a more current and potentially more reliable version.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R31): Updated the action from `MarcoIeni/release-plz-action` to `release-plz/action` for the release process.