### PR TITLE
feat(thegraph-core): gate the attestation module behind a crate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,7 +3407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -3477,7 +3477,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -9,11 +9,15 @@ edition = "2021"
 rust-version = "1.79.0"
 
 [features]
-default = []
+default = ["attestation"]
+attestation = ["alloy-eip712", "alloy-signers", "alloy-sol-types"]
 alloy-contract = ["alloy/contract"]
+alloy-eip712 = ["alloy/eip712"]
 alloy-full = ["alloy/full"]
 alloy-rlp = ["alloy/rlp"]
 alloy-signer-local = ["alloy/signer-local"]
+alloy-signers = ["alloy/signers"]
+alloy-sol-types = ["alloy/sol-types"]
 async-graphql-support = ["dep:async-graphql"]
 serde = ["dep:serde", "dep:serde_with", "alloy/serde"]
 subgraph-client = [
@@ -28,7 +32,7 @@ subgraph-client = [
 ]
 
 [dependencies]
-alloy = { version = "0.6", features = ["eip712", "signers", "sol-types"] }
+alloy = "0.6"
 async-graphql = { version = "7.0", optional = true }
 bs58 = "0.5"
 indoc = { version = "2.0.5", optional = true }

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -14,10 +14,13 @@
 // Re-export `alloy` crate
 pub use alloy;
 
+#[cfg(feature = "attestation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "attestation")))]
+#[cfg_attr(feature = "attestation", doc(inline))]
+pub use self::attestation::Attestation; // TODO: Remove as part of the next major version release
 #[doc(inline)]
 pub use self::{
     allocation_id::AllocationId,
-    attestation::Attestation,
     block::BlockPointer,
     deployment_id::{DeploymentId, ParseDeploymentIdError},
     indexer_id::IndexerId,
@@ -26,6 +29,8 @@ pub use self::{
 };
 
 mod allocation_id;
+#[cfg(feature = "attestation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "attestation")))]
 pub mod attestation;
 mod block;
 #[deprecated(


### PR DESCRIPTION
This pull request includes several changes to the `thegraph-core` project, focusing on feature management and dependency adjustments. The most important changes include the addition of a new feature, modifications to dependencies, and updates to module exports.

Feature management:

* Added a new feature `attestation` with associated dependencies `alloy-eip712`, `alloy-signers`, and `alloy-sol-types` in the `Cargo.toml` file.

Dependency adjustments:

* Simplified the `alloy` dependency by removing specific features in the `Cargo.toml` file.

Module exports:

* Updated `src/lib.rs` to conditionally export the `Attestation` module only when the `attestation` feature is enabled. [[1]](diffhunk://#diff-47485ed4ac689adc6116c212d831941f5119be76ac36a8d290fa4008d6616f01R17-L20) [[2]](diffhunk://#diff-47485ed4ac689adc6116c212d831941f5119be76ac36a8d290fa4008d6616f01R32-R33)