### PR TITLE
feat(thegraph-core): remove attestation feature from defaults set

### DIFF
--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.79.0"
 
 [features]
-default = ["attestation"]
+default = []
 attestation = ["alloy-eip712", "alloy-signers", "alloy-sol-types"]
 alloy-contract = ["alloy/contract"]
 alloy-eip712 = ["alloy/eip712"]

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -14,10 +14,6 @@
 // Re-export `alloy` crate
 pub use alloy;
 
-#[cfg(feature = "attestation")]
-#[cfg_attr(docsrs, doc(cfg(feature = "attestation")))]
-#[cfg_attr(feature = "attestation", doc(inline))]
-pub use self::attestation::Attestation; // TODO: Remove as part of the next major version release
 #[doc(inline)]
 pub use self::{
     allocation_id::AllocationId,


### PR DESCRIPTION
This pull request includes changes to `thegraph-core` to simplify the feature set and prepare for future updates. The most important changes include modifying the default features in `Cargo.toml` and removing the `Attestation` re-export from `lib.rs`.

Feature set simplification:

* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77L12-R12): Changed the default features to an empty list, removing `attestation` from the default set.

Code cleanup:

* [`thegraph-core/src/lib.rs`](diffhunk://#diff-47485ed4ac689adc6116c212d831941f5119be76ac36a8d290fa4008d6616f01L17-L20): Removed the `Attestation` re-export, which was previously marked for removal in the next major version release.