### PR TITLE
feat(thegraph-core): add fake-rs support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1884,16 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fake"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661cb0601b5f4050d1e65452c5b0ea555c0b3e88fb5ed7855906adc6c42523ef"
+dependencies = [
+ "deunicode",
+ "rand",
 ]
 
 [[package]]
@@ -4414,6 +4430,7 @@ dependencies = [
  "alloy",
  "async-graphql",
  "bs58",
+ "fake",
  "serde",
  "serde_with",
  "thiserror 1.0.69",

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -19,12 +19,14 @@ alloy-signer-local = ["alloy/signer-local"]
 alloy-signers = ["alloy/signers"]
 alloy-sol-types = ["alloy/sol-types"]
 async-graphql-support = ["dep:async-graphql"]
+fake = ["dep:fake"]
 serde = ["dep:serde", "dep:serde_with", "alloy/serde"]
 
 [dependencies]
 alloy = "0.7"
 async-graphql = { version = "7.0", optional = true }
 bs58 = "0.5"
+fake = { version = "3.0", optional = true }
 serde = { version = "1.0", optional = true }
 serde_with = { version = "3.8", optional = true }
 thiserror = "1.0"

--- a/thegraph-core/src/allocation_id.rs
+++ b/thegraph-core/src/allocation_id.rs
@@ -8,13 +8,26 @@ use alloy::primitives::Address;
 ///
 /// The `AllocationId` type implements the following formatting traits:
 ///
-/// - Use [`Display`] for formatting the `AllocationId` as an [EIP-55] checksum string.
-/// - Use [`LowerHex`] (or [`UpperHex`]) for formatting the `AllocationId` as a hexadecimal string.
+/// - Use [`std::fmt::Display`] for formatting the `AllocationId` as an [EIP-55] checksum string.
+/// - Use [`std::fmt::LowerHex`] (or [`std::fmt::UpperHex`]) for formatting   the `AllocationId` as
+///   a hexadecimal string.
+///
+/// See the [`Display`], [`LowerHex`], and [`UpperHex`] trait implementations for usage examples.
+///
+/// ## Generating test data
+///
+/// The `AllocationId` type implements the [`fake`] crate's [`fake::Dummy`] trait, allowing you to
+/// generate random `AllocationId` values for testing.
+///
+/// Note that the `fake` feature must be enabled to use this functionality.
+///
+/// See the [`Dummy`] trait impl for usage examples.
 ///
 /// [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
-/// [`Display`]: struct.AllocationId.html#impl-Display-for-AllocationId
-/// [`LowerHex`]: struct.AllocationId.html#impl-LowerHex-for-AllocationId
-/// [`UpperHex`]: struct.AllocationId.html#impl-UpperHex-for-AllocationId
+/// [`Display`]: #impl-Display-for-AllocationId
+/// [`LowerHex`]: #impl-LowerHex-for-AllocationId
+/// [`UpperHex`]: #impl-UpperHex-for-AllocationId
+/// [`Dummy`]: #impl-Dummy<Faker>-for-AllocationId
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocationId(Address);
 
@@ -41,8 +54,7 @@ impl std::fmt::Display for AllocationId {
     /// [`UpperHex`]: struct.AllocationId.html#impl-UpperHex-for-AllocationId
     ///
     /// ```rust
-    /// use thegraph_core::{allocation_id, AllocationId};
-    ///
+    /// # use thegraph_core::{allocation_id, AllocationId};
     /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// // Note the uppercase and lowercase hex characters in the checksum
@@ -66,8 +78,7 @@ impl std::fmt::Debug for AllocationId {
     /// [`UpperHex`]: struct.AllocationId.html#impl-UpperHex-for-AllocationId
     ///
     /// ```rust
-    /// use thegraph_core::{allocation_id, AllocationId};
-    ///
+    /// # use thegraph_core::{allocation_id, AllocationId};
     /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// assert_eq!(format!("{:?}", ID), "0x0002c67268fb8c8917f36f865a0cbdf5292fa68d");
@@ -83,8 +94,7 @@ impl std::fmt::LowerHex for AllocationId {
     /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
     ///
     /// ```rust
-    /// use thegraph_core::{allocation_id, AllocationId};
-    ///
+    /// # use thegraph_core::{allocation_id, AllocationId};
     /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// // Lower hex
@@ -104,8 +114,7 @@ impl std::fmt::UpperHex for AllocationId {
     /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
     ///
     /// ```rust
-    /// use thegraph_core::{allocation_id, AllocationId};
-    ///
+    /// # use thegraph_core::{allocation_id, AllocationId};
     /// const ID: AllocationId = allocation_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// // Upper hex
@@ -172,6 +181,24 @@ impl serde::Serialize for AllocationId {
         S: serde::Serializer,
     {
         self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "fake")]
+/// To use the [`fake`] crate to generate random [`AllocationId`] values, **the `fake` feature must
+/// be enabled.**
+///
+/// ```rust
+/// # use thegraph_core::AllocationId;
+/// # use fake::Fake;
+/// let allocation_id = fake::Faker.fake::<AllocationId>();
+///
+/// println!("AllocationId: {:#x}", allocation_id);
+/// ```
+impl fake::Dummy<fake::Faker> for AllocationId {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let bytes = <[u8; 20]>::dummy_with_rng(config, rng);
+        Self(Address::from(bytes))
     }
 }
 

--- a/thegraph-core/src/indexer_id.rs
+++ b/thegraph-core/src/indexer_id.rs
@@ -8,13 +8,26 @@ use alloy::primitives::Address;
 ///
 /// The `IndexerId` type implements the following formatting traits:
 ///
-/// - Use [`Display`] for formatting the `IndexerId` as an [EIP-55] checksum string.
-/// - Use [`LowerHex`] (or [`UpperHex`]) for formatting the `IndexerId` as a hexadecimal string.
+/// - Use [`std::fmt::Display`] for formatting the `IndexerId` as an [EIP-55] checksum string.
+/// - Use [`std::fmt::LowerHex`] (or [`std::fmt::UpperHex`]) for formatting   the `IndexerId` as a
+///   hexadecimal string.
+///
+/// See the [`Display`], [`LowerHex`], and [`UpperHex`] trait implementations for usage examples.
+///
+/// ## Generating test data
+///
+/// The `IndexerId` type implements the [`fake`] crate's [`fake::Dummy`] trait, allowing you to
+/// generate random `IndexerId` values for testing.
+///
+/// Note that the `fake` feature must be enabled to use this functionality.
+///
+/// See the [`Dummy`] trait impl for usage examples.
 ///
 /// [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
-/// [`Display`]: struct.IndexerId.html#impl-Display-for-IndexerId
-/// [`LowerHex`]: struct.IndexerId.html#impl-LowerHex-for-IndexerId
-/// [`UpperHex`]: struct.IndexerId.html#impl-UpperHex-for-IndexerId
+/// [`Display`]: #impl-Display-for-IndexerId
+/// [`LowerHex`]: #impl-LowerHex-for-IndexerId
+/// [`UpperHex`]: #impl-UpperHex-for-IndexerId
+/// [`Dummy`]: #impl-Dummy<Faker>-for-IndexerId
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndexerId(Address);
 
@@ -41,7 +54,7 @@ impl std::fmt::Display for IndexerId {
     /// [`UpperHex`]: struct.IndexerId.html#impl-UpperHex-for-IndexerId
     ///
     /// ```rust
-    /// use thegraph_core::{indexer_id, IndexerId};
+    /// # use thegraph_core::{indexer_id, IndexerId};
     ///
     /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
@@ -66,8 +79,7 @@ impl std::fmt::Debug for IndexerId {
     /// [`UpperHex`]: struct.IndexerId.html#impl-UpperHex-for-IndexerId
     ///
     /// ```rust
-    /// use thegraph_core::{indexer_id, IndexerId};
-    ///
+    /// # use thegraph_core::{indexer_id, IndexerId};
     /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// assert_eq!(format!("{:?}", ID), "0x0002c67268fb8c8917f36f865a0cbdf5292fa68d");
@@ -83,8 +95,7 @@ impl std::fmt::LowerHex for IndexerId {
     /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
     ///
     /// ```rust
-    /// use thegraph_core::{indexer_id, IndexerId};
-    ///
+    /// # use thegraph_core::{indexer_id, IndexerId};
     /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// // Lower hex
@@ -104,8 +115,7 @@ impl std::fmt::UpperHex for IndexerId {
     /// Note that the alternate flag, `#`, adds a `0x` in front of the output.
     ///
     /// ```rust
-    /// use thegraph_core::{indexer_id, IndexerId};
-    ///
+    /// # use thegraph_core::{indexer_id, IndexerId};
     /// const ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
     ///
     /// // Upper hex
@@ -175,25 +185,41 @@ impl serde::Serialize for IndexerId {
     }
 }
 
+#[cfg(feature = "fake")]
+/// To use the [`fake`] crate to generate random [`IndexerId`] values, **the `fake` feature must
+/// be enabled.**
+///
+/// ```rust
+/// # use thegraph_core::IndexerId;
+/// # use fake::Fake;
+/// let indexer_id = fake::Faker.fake::<IndexerId>();
+///
+/// println!("IndexerId: {:#x}", indexer_id);
+/// ```
+impl fake::Dummy<fake::Faker> for IndexerId {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let bytes = <[u8; 20]>::dummy_with_rng(config, rng);
+        Self(Address::from(bytes))
+    }
+}
+
 /// Converts a sequence of string literals containing hex-encoded data into a new [`IndexerId`]
 /// at compile time.
 ///
 /// To create an `IndexerId` from a string literal (no `0x` prefix) at compile time:
 ///
 /// ```rust
-/// use thegraph_core::{indexer_id, IndexerId};
-///
+/// # use thegraph_core::{indexer_id, IndexerId};
 /// const INDEXER_ID: IndexerId = indexer_id!("0002c67268fb8c8917f36f865a0cbdf5292fa68d");
 /// ```
 ///
 /// If no argument is provided, the macro will create an `IndexerId` with the zero address:
 ///
 /// ```rust
-/// use thegraph_core::{
-///     alloy::primitives::Address,
-///     indexer_id, IndexerId
-/// };
-///
+/// # use thegraph_core::{
+/// #    alloy::primitives::Address,
+/// #    indexer_id, IndexerId
+/// # };
 /// const INDEXER_ID: IndexerId = indexer_id!();
 ///
 /// assert_eq!(INDEXER_ID, Address::ZERO);

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -1,12 +1,31 @@
 //! Rust core modules for _The Graph_ network.
 //!
-//! # Re-exports
+//! # Re-export of the [`alloy`] crate
 //!
-//! This crate re-exports the `alloy` crate, which provides essential types, traits, and macros.
+//! This crate re-exports the [`alloy`] crate, which provides essential types, traits, and macros.
 //!
-//! As this crate relies on types from the `alloy` crate, it is advisable to use the re-exported
-//! `alloy` crate instead of adding it to your `Cargo.toml` file. This approach helps to avoid
-//! potential future crate version conflicts.
+//! To avoid potential future crate version conflicts, it is recommended to use the re-exported
+//! `alloy` crate instead of adding it directly to your `Cargo.toml` file.
+//!
+//! For convenience, this crate also re-exports the features of the `alloy` crate. These features
+//! follow the naming convention `alloy-<feature>`. For example, the `alloy-signers` and
+//! `alloy-signer-local` features enable the `signers` and `signer-local` optional features of the
+//! `alloy` crate, respectively.
+//!
+//! If you need to enable an `alloy` crate feature that is not yet re-exported by this crate, you
+//! can enable the `alloy-full` feature to enable all `alloy` features.
+//!
+//! # Features
+//!
+//! The following features are available for this crate:
+//!
+//! - `attestation`: Enables the `attestation` module, which provides types and functions for
+//!    attestation-related operations.
+//! - `async-graphql-support`: Enables support for the [`async-graphql`] crate.
+//! - `fake`: Enables the [`fake`] crate integration for generating random test data.
+//! - `serde`: Enables [`serde`] serialization and deserialization support for types in this crate.
+//!
+//! Additionally, this crate re-exports other features from the `alloy` crate as described above.
 
 // Enable `doc_cfg` feature for `docs.rs`
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/thegraph-core/src/proof_of_indexing.rs
+++ b/thegraph-core/src/proof_of_indexing.rs
@@ -8,6 +8,17 @@ use alloy::primitives::B256;
 
 /// A Proof of Indexing, "POI", is a cryptographic proof submitted by indexers to demonstrate that
 /// they have accurately indexed a subgraph.
+///
+/// ## Generating test data
+///
+/// The `ProofOfIndexing` type implements the [`fake`] crate's [`fake::Dummy`] trait, allowing you
+/// to generate random `ProofOfIndexing` values for testing.
+///
+/// Note that the `fake` feature must be enabled to use this functionality.
+///
+/// See the [`Dummy`] trait impl for usage examples.
+///
+/// [`Dummy`]: #impl-Dummy<Faker>-for-ProofOfIndexing
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc(alias = "poi")]
 pub struct ProofOfIndexing(B256);
@@ -99,6 +110,24 @@ impl serde::Serialize for ProofOfIndexing {
         S: serde::Serializer,
     {
         self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "fake")]
+/// To use the [`fake`] crate to generate random [`ProofOfIndexing`] values, **the `fake` feature
+/// must be enabled.**
+///
+/// ```rust
+/// # use thegraph_core::ProofOfIndexing;
+/// # use fake::Fake;
+/// let poi = fake::Faker.fake::<ProofOfIndexing>();
+///
+/// println!("ProofOfIndexing: {}", poi);
+/// ```
+impl fake::Dummy<fake::Faker> for ProofOfIndexing {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let bytes = <[u8; 32]>::dummy_with_rng(config, rng);
+        Self(B256::new(bytes))
     }
 }
 

--- a/thegraph-core/src/subgraph_id.rs
+++ b/thegraph-core/src/subgraph_id.rs
@@ -13,6 +13,17 @@ pub enum ParseSubgraphIdError {
 }
 
 /// A Subgraph ID is a 32-byte identifier for a subgraph.
+///
+/// ## Generating test data
+///
+/// The `SubgraphId` type implements the [`fake`] crate's [`fake::Dummy`] trait, allowing you to
+/// generate random `SubgraphId` values for testing.
+///
+/// Note that the `fake` feature must be enabled to use this functionality.
+///
+/// See the [`Dummy`] trait impl for usage examples.
+///
+/// [`Dummy`]: #impl-Dummy<Faker>-for-SubgraphId
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
     feature = "serde",
@@ -107,8 +118,7 @@ impl std::fmt::Display for SubgraphId {
     /// Format the `SubgraphId` as a base58-encoded string.
     ///
     /// ```rust
-    /// use thegraph_core::{subgraph_id, SubgraphId};
-    ///
+    /// # use thegraph_core::{subgraph_id, SubgraphId};
     /// const ID: SubgraphId = subgraph_id!("DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
     ///
     /// assert_eq!(format!("{}", ID), "DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
@@ -123,8 +133,7 @@ impl std::fmt::Debug for SubgraphId {
     /// Format the `SubgraphId` as a debug string.
     ///
     /// ```rust
-    /// use thegraph_core::{subgraph_id, SubgraphId};
-    ///
+    /// # use thegraph_core::{subgraph_id, SubgraphId};
     /// const ID: SubgraphId = subgraph_id!("DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
     ///
     /// assert_eq!(format!("{:?}", ID), "SubgraphId(DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp)");
@@ -134,22 +143,38 @@ impl std::fmt::Debug for SubgraphId {
     }
 }
 
+#[cfg(feature = "fake")]
+/// To use the [`fake`] crate to generate random [`SubgraphId`] values, **the `fake` feature must
+/// be enabled.**
+///
+/// ```rust
+/// # use thegraph_core::SubgraphId;
+/// # use fake::Fake;
+/// let subgraph_id = fake::Faker.fake::<SubgraphId>();
+///
+/// println!("SubgraphId: {}", subgraph_id);
+/// ```
+impl fake::Dummy<fake::Faker> for SubgraphId {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let bytes = <[u8; 32]>::dummy_with_rng(config, rng);
+        Self(B256::new(bytes))
+    }
+}
+
 /// Converts a sequence of string literals containing 32-bytes Base58-encoded data into a new
 /// [`SubgraphId`] at compile time.
 ///
 /// To create an `SubgraphId` from a string literal (Base58) at compile time:
 ///
 /// ```rust
-/// use thegraph_core::{subgraph_id, SubgraphId};
-///
+/// # use thegraph_core::{subgraph_id, SubgraphId};
 /// const SUBGRAPH_ID: SubgraphId = subgraph_id!("DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp");
 /// ```
 ///
 /// If no argument is provided, the macro will create an `SubgraphId` with the zero ID:
 ///
 /// ```rust
-/// use thegraph_core::{subgraph_id, SubgraphId};
-///
+/// # use thegraph_core::{subgraph_id, SubgraphId};
 /// const SUBGRAPH_ID: SubgraphId = subgraph_id!();
 ///
 /// assert_eq!(SUBGRAPH_ID, SubgraphId::ZERO);


### PR DESCRIPTION
This pull request adds support for generating fake data in the `thegraph-core` package. The changes include adding a new dependency for the `fake` crate and implementing the `fake::Dummy` trait for several structs to facilitate the creation of fake data.

### Addition of Fake Data Support:

* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77R22-R29): Added `fake` as an optional dependency.

### Implementation of `fake::Dummy` Trait:

* [`thegraph-core/src/allocation_id.rs`](diffhunk://#diff-2e15fb7e306b4c402d0b6243c330954a6c96d1c98d82004d3594a98175119ae9R178-R185): Implemented `fake::Dummy` for `AllocationId` to generate fake data for this struct.
* [`thegraph-core/src/deployment_id.rs`](diffhunk://#diff-27a2f380f335b2b2b698c5d722b5ccc50425f900e99497ae58ea827028f1dcfaR147-R154): Implemented `fake::Dummy` for `DeploymentId` to generate fake data for this struct.
* [`thegraph-core/src/indexer_id.rs`](diffhunk://#diff-46278ae7fc17972e75fcf4e988b1cb62c3e070174ddcd7be681510e9109eac8fR178-R185): Implemented `fake::Dummy` for `IndexerId` to generate fake data for this struct.
* [`thegraph-core/src/proof_of_indexing.rs`](diffhunk://#diff-7067ed08d074f8f9e58ccb64402e5f2dbaf86f593f5f08e015f4649ff4173d0cR105-R112): Implemented `fake::Dummy` for `ProofOfIndexing` to generate fake data for this struct.
* [`thegraph-core/src/subgraph_id.rs`](diffhunk://#diff-3a307cd6e59fce3966e151fe970b8bfdae1a2c0919098c870c03465e9fa2daa2R137-R144): Implemented `fake::Dummy` for `SubgraphId` to generate fake data for this struct.