### PR TITLE
chore(thegraph-core): rename async-graphql support feature

### DIFF
--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -18,7 +18,7 @@ alloy-rlp = ["alloy/rlp"]
 alloy-signer-local = ["alloy/signer-local"]
 alloy-signers = ["alloy/signers"]
 alloy-sol-types = ["alloy/sol-types"]
-async-graphql-support = ["dep:async-graphql"]
+async-graphql = ["dep:async-graphql"]
 fake = ["dep:fake"]
 serde = ["dep:serde", "dep:serde_with", "alloy/serde"]
 

--- a/thegraph-core/src/deployment_id.rs
+++ b/thegraph-core/src/deployment_id.rs
@@ -170,7 +170,7 @@ impl fake::Dummy<fake::Faker> for DeploymentId {
     }
 }
 
-#[cfg(feature = "async-graphql-support")]
+#[cfg(feature = "async-graphql")]
 #[async_graphql::Scalar]
 impl async_graphql::ScalarType for DeploymentId {
     fn parse(value: async_graphql::Value) -> async_graphql::InputValueResult<Self> {

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! - `attestation`: Enables the `attestation` module, which provides types and functions for
 //!    attestation-related operations.
-//! - `async-graphql-support`: Enables support for the [`async-graphql`] crate.
+//! - `async-graphql`: Enables support for the [`async-graphql`] crate.
 //! - `fake`: Enables the [`fake`] crate integration for generating random test data.
 //! - `serde`: Enables [`serde`] serialization and deserialization support for types in this crate.
 //!


### PR DESCRIPTION
This pull request includes changes to the `thegraph-core` package to update the feature name for `async-graphql`. The most significant changes involve modifying the feature name in the `Cargo.toml` file, updating the conditional compilation attribute, and adjusting the feature documentation.

Feature name update:

* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77L21-R21): Changed the feature name from `async-graphql-support` to `async-graphql`.
* [`thegraph-core/src/deployment_id.rs`](diffhunk://#diff-27a2f380f335b2b2b698c5d722b5ccc50425f900e99497ae58ea827028f1dcfaL173-R173): Updated the `#[cfg(feature = "async-graphql-support")]` attribute to `#[cfg(feature = "async-graphql")]`.
* [`thegraph-core/src/lib.rs`](diffhunk://#diff-47485ed4ac689adc6116c212d831941f5119be76ac36a8d290fa4008d6616f01L24-R24): Modified the feature documentation to reflect the new feature name `async-graphql`.