### PR TITLE
chore(ci): add semver compatibility and external types checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,26 @@ jobs:
           cache: false
 
       - run: cargo +nightly fmt --all -- --check
+
+  check-external-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1
+        with:
+          toolchain: nightly-2024-06-30
+          # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
+          cache: false
+      - uses: baptiste0928/cargo-install@904927dbe77864e0f2281519fe9d5bd097a220b3 # v3
+        with:
+          crate: cargo-check-external-types
+      - run: cargo check-external-types --all-features --manifest-path thegraph-core/Cargo.toml
+
+  check-semver-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: thegraph-core
+

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -38,3 +38,25 @@ alloy = { version = "0.7", features = ["signer-local"] }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "alloy",
+    "alloy::*",
+    "alloy_primitives",
+    "alloy_primitives::*",
+    "alloy_signer",
+    "alloy_signer::*",
+    "alloy_sol_types",
+    "alloy_sol_types::*",
+    "async_graphql",
+    "async_graphql::*",
+    "fake",
+    "fake::*",
+    "headers",
+    "headers::*",
+    "headers_core",
+    "headers_core::*",
+    "serde",
+    "serde::*",
+]


### PR DESCRIPTION
This pull request introduces new workflows in the CI configuration and updates the `Cargo.toml` file to improve the project's build and verification processes. The most relevant changes include adding new jobs to the GitHub Actions workflow and specifying allowed external types in the `Cargo.toml` file.

### CI Workflow Enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR84-R105): Added `check-external-types` job to run `cargo check-external-types` using the nightly Rust toolchain.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR84-R105): Added `check-semver-compat` job to check for semantic version compatibility using `cargo-semver-checks-action`.

### Cargo Configuration Update:

* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77R40-R45): Added `[package.metadata.cargo_check_external_types]` section to specify allowed external types for the `cargo-check-external-types` tool.