### PR TITLE
feat(thegraph-core): add graph-attestation http header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,6 +2300,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,7 +4446,9 @@ dependencies = [
  "async-graphql",
  "bs58",
  "fake",
+ "headers",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 1.0.69",
 ]

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -20,6 +20,11 @@ alloy-signers = ["alloy/signers"]
 alloy-sol-types = ["alloy/sol-types"]
 async-graphql = ["dep:async-graphql"]
 fake = ["dep:fake"]
+headers = [
+    "dep:headers",
+    # Required by headers::graph_attestation
+    "alloy/serde", "dep:serde", "dep:serde_json",
+]
 serde = ["dep:serde", "dep:serde_with", "alloy/serde"]
 
 [dependencies]
@@ -27,7 +32,9 @@ alloy = "0.7"
 async-graphql = { version = "7.0", optional = true }
 bs58 = "0.5"
 fake = { version = "3.0", optional = true }
+headers = { version = "0.4.0", optional = true }
 serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0.133", optional = true }
 serde_with = { version = "3.8", optional = true }
 thiserror = "1.0"
 

--- a/thegraph-core/src/attestation.rs
+++ b/thegraph-core/src/attestation.rs
@@ -169,6 +169,20 @@ pub fn recover_allocation(
         .map_err(|_| VerificationError::FailedSignerRecovery)
 }
 
+#[cfg(feature = "fake")]
+impl fake::Dummy<fake::Faker> for Attestation {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        Self {
+            request_cid: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            response_cid: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            deployment: DeploymentId::dummy_with_rng(config, rng).into(),
+            r: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            s: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            v: u8::dummy_with_rng(config, rng),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::{

--- a/thegraph-core/src/headers.rs
+++ b/thegraph-core/src/headers.rs
@@ -1,0 +1,8 @@
+//! Common HTTP _typed headers_ used across _The Graph_ network services.
+
+#[cfg(feature = "attestation")]
+mod graph_attestation;
+
+#[cfg(feature = "attestation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "attestation"), inline))]
+pub use graph_attestation::GraphAttestation;

--- a/thegraph-core/src/headers/graph_attestation.rs
+++ b/thegraph-core/src/headers/graph_attestation.rs
@@ -1,0 +1,247 @@
+use alloy::primitives::B256;
+use headers::{Error as HeaderError, HeaderName, HeaderValue};
+
+use crate::attestation::Attestation;
+
+static HEADER_NAME: HeaderName = HeaderName::from_static("graph-attestation");
+
+/// An HTTP _typed header_ for the `graph-attestation` header.
+///
+/// The `graph-attestation` header can contain a JSON-encoded [`Attestation`] struct, or an empty
+/// string if no attestation is provided.
+///
+/// When deserializing the header value, if the value is empty, it will be deserialized as `None`.
+/// If the value is not empty, but cannot be deserialized as an [`Attestation`], the header is
+/// considered invalid.
+#[derive(Debug, Clone)]
+pub struct GraphAttestation(pub Option<Attestation>);
+
+impl headers::Header for GraphAttestation {
+    fn name() -> &'static HeaderName {
+        &HEADER_NAME
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, HeaderError>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        // Get the first header value, and convert it to a string.
+        // If it's not present, or it's an invalid string, return an error
+        let value = values
+            .next()
+            .ok_or_else(HeaderError::invalid)?
+            .to_str()
+            .map_err(|_| HeaderError::invalid())?;
+
+        // If the value is empty, return None, otherwise try to deserialize it
+        let attestation = if value.is_empty() {
+            None
+        } else {
+            let attestation = serde_json::from_str::<'_, AttestationSerde>(value)
+                .map_err(|_| HeaderError::invalid())?;
+            Some(attestation.into())
+        };
+
+        Ok(Self(attestation))
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        // Serialize the attestation as a JSON string, and convert it to a `HeaderValue`.
+        // If the attestation is `None`, serialize an empty string.
+        let value = self
+            .0
+            .as_ref()
+            .and_then(|att| {
+                let att = serde_json::to_string(&AttestationSerde::from(att)).ok()?;
+                Some(HeaderValue::from_str(att.as_str()).expect("header to be valid utf-8"))
+            })
+            .unwrap_or_else(|| HeaderValue::from_static(""));
+
+        values.extend(std::iter::once(value));
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AttestationSerde {
+    #[serde(rename = "requestCID")]
+    request_cid: B256,
+    #[serde(rename = "responseCID")]
+    response_cid: B256,
+    #[serde(rename = "subgraphDeploymentID")]
+    deployment: B256,
+    r: B256,
+    s: B256,
+    v: u8,
+}
+
+impl From<AttestationSerde> for Attestation {
+    fn from(value: AttestationSerde) -> Self {
+        Self {
+            request_cid: value.request_cid,
+            response_cid: value.response_cid,
+            deployment: value.deployment,
+            r: value.r,
+            s: value.s,
+            v: value.v,
+        }
+    }
+}
+
+impl From<&Attestation> for AttestationSerde {
+    fn from(value: &Attestation) -> Self {
+        Self {
+            request_cid: value.request_cid,
+            response_cid: value.response_cid,
+            deployment: value.deployment,
+            r: value.r,
+            s: value.s,
+            v: value.v,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "fake"))]
+mod tests {
+    use fake::{Fake, Faker};
+    use headers::{Header, HeaderValue};
+
+    use super::{AttestationSerde, GraphAttestation};
+    use crate::attestation::Attestation;
+
+    #[test]
+    fn encode_attestation_into_header() {
+        //* Given
+        let attestation = Faker.fake::<Attestation>();
+
+        let mut headers = vec![];
+
+        //* When
+        let header = GraphAttestation(Some(attestation.clone()));
+
+        header.encode(&mut headers);
+
+        //* Then
+        let value = headers
+            .first()
+            .expect("header to have been encoded")
+            .to_str()
+            .expect("header to be valid utf8");
+
+        let att: AttestationSerde = serde_json::from_str(value).expect("header to be valid json");
+        assert_eq!(attestation.request_cid, att.request_cid);
+        assert_eq!(attestation.response_cid, att.response_cid);
+        assert_eq!(attestation.deployment, att.deployment);
+        assert_eq!(attestation.r, att.r);
+        assert_eq!(attestation.s, att.s);
+        assert_eq!(attestation.v, att.v);
+    }
+
+    #[test]
+    fn encode_empty_attestation_header() {
+        //* Given
+        let mut headers = vec![];
+
+        //* When
+        let header = GraphAttestation(None);
+
+        header.encode(&mut headers);
+
+        //* Then
+        let value = headers
+            .first()
+            .expect("header to have been encoded")
+            .to_str()
+            .expect("header to be valid utf-8");
+
+        assert_eq!(value, "");
+    }
+
+    #[test]
+    fn decode_attestation_from_valid_header() {
+        //* Given
+        let attestation = Faker.fake::<Attestation>();
+
+        let header = {
+            let value = serde_json::to_string(&AttestationSerde::from(&attestation)).unwrap();
+            HeaderValue::from_str(value.as_str()).unwrap()
+        };
+        let headers = [header];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        let GraphAttestation(att) = header.expect("header to be valid");
+        let att = att.expect("attestation to be present");
+
+        assert_eq!(attestation.request_cid, att.request_cid);
+        assert_eq!(attestation.response_cid, att.response_cid);
+        assert_eq!(attestation.deployment, att.deployment);
+        assert_eq!(attestation.r, att.r);
+        assert_eq!(attestation.s, att.s);
+        assert_eq!(attestation.v, att.v);
+    }
+
+    #[test]
+    fn decode_attestation_from_first_header() {
+        //* Given
+        let attestation = Faker.fake::<Attestation>();
+
+        let header = {
+            let value = serde_json::to_string(&AttestationSerde::from(&attestation)).unwrap();
+            HeaderValue::from_str(&value).unwrap()
+        };
+        let headers = [
+            header,
+            HeaderValue::from_static("invalid"),
+            HeaderValue::from_static(""),
+        ];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        let GraphAttestation(attestation) = header.expect("header to be valid");
+        assert!(attestation.is_some());
+    }
+
+    #[test]
+    fn decode_empty_attestation_from_valid_header() {
+        //* Given
+        let header = HeaderValue::from_static("");
+        let headers = [header];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        let GraphAttestation(attestation) = header.expect("header to be valid");
+        assert!(attestation.is_none());
+    }
+
+    #[test]
+    fn fail_decode_attestation_from_invalid_header() {
+        //* Given
+        let header = HeaderValue::from_static("invalid");
+        let headers = [header];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        assert!(header.is_err());
+    }
+
+    #[test]
+    fn fail_decode_attestation_if_no_headers() {
+        //* Given
+        let headers = [];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        assert!(header.is_err());
+    }
+}

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -23,6 +23,8 @@
 //!    attestation-related operations.
 //! - `async-graphql`: Enables support for the [`async-graphql`] crate.
 //! - `fake`: Enables the [`fake`] crate integration for generating random test data.
+//! - `headers`: Enables the `headers` module, which provides common HTTP _typed headers_ used
+//!    across _The Graph_ network services.
 //! - `serde`: Enables [`serde`] serialization and deserialization support for types in this crate.
 //!
 //! Additionally, this crate re-exports other features from the `alloy` crate as described above.
@@ -49,6 +51,10 @@ mod allocation_id;
 pub mod attestation;
 mod block;
 mod deployment_id;
+
+#[cfg(feature = "headers")]
+#[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
+pub mod headers;
 mod indexer_id;
 mod proof_of_indexing;
 mod subgraph_id;


### PR DESCRIPTION
This pull request includes several changes to the `thegraph-core` package, focusing on supporting HTTP headers and enhancing the attestation functionality. The most significant changes include adding a new `headers` module, implementing a `GraphAttestation` header, and updating dependencies.

### New Features and Enhancements:

* **New Headers Module:**
  - Added a new `headers` module to manage common HTTP _typed headers_ used across The Graph network services. (`thegraph-core/src/headers.rs`)
  - Introduced the `GraphAttestation` header within the new `headers` module, which can handle JSON-encoded `Attestation` structs. (`thegraph-core/src/headers/graph_attestation.rs`)

* **Attestation Enhancements:**
  - Added support for generating fake `Attestation` data using the `fake` crate. (`thegraph-core/src/attestation.rs`)