### PR TITLE
feat(thegraph-core): implement fake trait for attestation type

### DIFF
--- a/thegraph-core/src/attestation.rs
+++ b/thegraph-core/src/attestation.rs
@@ -169,6 +169,20 @@ pub fn recover_allocation(
         .map_err(|_| VerificationError::FailedSignerRecovery)
 }
 
+#[cfg(feature = "fake")]
+impl fake::Dummy<fake::Faker> for Attestation {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        Self {
+            request_cid: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            response_cid: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            deployment: DeploymentId::dummy_with_rng(config, rng).into(),
+            r: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            s: B256::from(<[u8; 32]>::dummy_with_rng(config, rng)),
+            v: u8::dummy_with_rng(config, rng),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::{


### PR DESCRIPTION
This pull request includes an addition to the `thegraph-core/src/attestation.rs` file to support the creation of fake `Attestation` objects for testing purposes. The most important change is the implementation of the `fake::Dummy` trait for the `Attestation` struct.

Enhancements for testing:

* [`thegraph-core/src/attestation.rs`](diffhunk://#diff-da19c1761e5c3cd0d98dcc2ffe1b1b2b8d87d9f7840d21cff67c8d4cef3b8ba9R172-R185): Implemented the `fake::Dummy` trait for the `Attestation` struct to allow the creation of fake `Attestation` objects using the `fake` crate. This includes generating random values for `request_cid`, `response_cid`, `deployment`, `r`, `s`, and `v` fields.