### PR TITLE
feat(thegraph-headers): add headers crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,6 +2300,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4442,6 +4466,17 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "thegraph-headers"
+version = "0.1.0"
+dependencies = [
+ "fake",
+ "headers",
+ "serde",
+ "serde_json",
+ "thegraph-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "thegraph-core",
     "thegraph-graphql-http",
     "thegraph-client-subgraphs",
+    "thegraph-headers",
 ]

--- a/thegraph-headers/Cargo.toml
+++ b/thegraph-headers/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "thegraph-headers"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+attestation = ["thegraph-core/attestation"]
+
+[dependencies]
+headers = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thegraph-core = { version = "0.9.0", path = "../thegraph-core", features = ["serde"] }
+
+[dev-dependencies]
+fake = "3.0.1"
+thegraph-core = { path = "../thegraph-core", features = ["fake"] }

--- a/thegraph-headers/src/graph_attestable.rs
+++ b/thegraph-headers/src/graph_attestable.rs
@@ -1,0 +1,47 @@
+//! An HTTP _typed header_ for the `graph-attestable` header.
+//!
+//! This HTTP header is used to indicate whether a response is _attestable_ or not.
+
+use headers::{Error as HeaderError, Header, HeaderName, HeaderValue};
+
+/// The HTTP header name for the `graph-attestable` header.
+pub const HEADER_NAME: &str = "graph-attestable";
+
+/// An HTTP _typed header_ for the `graph-attestable` header.
+///
+/// This HTTP header is used to indicate whether a response is attestable or not.
+///
+/// The `graph-attestable` header can contain a boolean value, either `true` or `false`.
+#[derive(Debug, Clone)]
+pub struct GraphAttestable(pub bool);
+
+impl Header for GraphAttestable {
+    fn name() -> &'static HeaderName {
+        static HTTP_HEADER_NAME: HeaderName = HeaderName::from_static(HEADER_NAME);
+        &HTTP_HEADER_NAME
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, HeaderError>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let value = values.next().ok_or_else(HeaderError::invalid)?;
+        if value == "true" {
+            Ok(Self(true))
+        } else if value == "false" {
+            Ok(Self(false))
+        } else {
+            Err(HeaderError::invalid())
+        }
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        let value = if self.0 {
+            HeaderValue::from_static("true")
+        } else {
+            HeaderValue::from_static("false")
+        };
+        values.extend(std::iter::once(value));
+    }
+}

--- a/thegraph-headers/src/graph_attestation.rs
+++ b/thegraph-headers/src/graph_attestation.rs
@@ -1,0 +1,203 @@
+//! An HTTP _typed header_ for the `graph-attestation` header.
+//!
+//! The `graph-attestation` header can contain a JSON-encoded [`Attestation`] struct, or an empty
+//! string if no attestation is provided.
+
+use headers::{Error as HeaderError, HeaderName, HeaderValue};
+use thegraph_core::alloy::primitives::B256;
+pub use thegraph_core::attestation::Attestation;
+
+/// The HTTP header name for the `graph-attestation` header.
+pub const HEADER_NAME: &str = "graph-attestation";
+
+/// An HTTP _typed header_ for the `graph-attestation` header.
+///
+/// The `graph-attestation` header can contain a JSON-encoded [`Attestation`] struct, or an empty
+/// string if no attestation is provided.
+#[derive(Debug, Clone)]
+pub struct GraphAttestation(pub Attestation);
+
+impl headers::Header for GraphAttestation {
+    fn name() -> &'static HeaderName {
+        static HTTP_HEADER_NAME: HeaderName = HeaderName::from_static(HEADER_NAME);
+        &HTTP_HEADER_NAME
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, HeaderError>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        // Get the first header value, and try to deserialize it into an `Attestation`.
+        let value = values.next().ok_or_else(HeaderError::invalid)?;
+        let attestation = serde_json::from_slice::<'_, AttestationSerde>(value.as_bytes())
+            .map_err(|_| HeaderError::invalid())?;
+        Ok(Self(attestation.into()))
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        // Serialize the attestation as a JSON string, and convert it to a `HeaderValue`.
+        let bytes =
+            serde_json::to_vec(&AttestationSerde::from(&self.0)).expect("header to be valid json");
+        let value = HeaderValue::from_bytes(&bytes).expect("header to be valid utf-8");
+        values.extend(std::iter::once(value));
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AttestationSerde {
+    #[serde(rename = "requestCID")]
+    request_cid: B256,
+    #[serde(rename = "responseCID")]
+    response_cid: B256,
+    #[serde(rename = "subgraphDeploymentID")]
+    deployment: B256,
+    r: B256,
+    s: B256,
+    v: u8,
+}
+
+impl From<AttestationSerde> for Attestation {
+    fn from(value: AttestationSerde) -> Self {
+        Self {
+            request_cid: value.request_cid,
+            response_cid: value.response_cid,
+            deployment: value.deployment,
+            r: value.r,
+            s: value.s,
+            v: value.v,
+        }
+    }
+}
+
+impl From<&Attestation> for AttestationSerde {
+    fn from(value: &Attestation) -> Self {
+        Self {
+            request_cid: value.request_cid,
+            response_cid: value.response_cid,
+            deployment: value.deployment,
+            r: value.r,
+            s: value.s,
+            v: value.v,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fake::{Fake, Faker};
+    use headers::{Header, HeaderValue};
+    use thegraph_core::attestation::Attestation;
+
+    use super::{AttestationSerde, GraphAttestation};
+
+    #[test]
+    fn encode_attestation_into_header() {
+        //* Given
+        let attestation = Faker.fake::<Attestation>();
+
+        let mut headers = vec![];
+
+        //* When
+        let header = GraphAttestation(attestation.clone());
+
+        header.encode(&mut headers);
+
+        //* Then
+        let value = headers.first().expect("header to have been encoded");
+
+        let att: AttestationSerde =
+            serde_json::from_slice(value.as_bytes()).expect("header to be valid json");
+        assert_eq!(attestation.request_cid, att.request_cid);
+        assert_eq!(attestation.response_cid, att.response_cid);
+        assert_eq!(attestation.deployment, att.deployment);
+        assert_eq!(attestation.r, att.r);
+        assert_eq!(attestation.s, att.s);
+        assert_eq!(attestation.v, att.v);
+    }
+
+    #[test]
+    fn decode_attestation_from_valid_header() {
+        //* Given
+        let attestation = Faker.fake::<Attestation>();
+
+        let header = {
+            let value = serde_json::to_string(&AttestationSerde::from(&attestation)).unwrap();
+            HeaderValue::from_str(value.as_str()).unwrap()
+        };
+        let headers = [header];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        let GraphAttestation(att) = header.expect("header to be valid");
+
+        assert_eq!(attestation.request_cid, att.request_cid);
+        assert_eq!(attestation.response_cid, att.response_cid);
+        assert_eq!(attestation.deployment, att.deployment);
+        assert_eq!(attestation.r, att.r);
+        assert_eq!(attestation.s, att.s);
+        assert_eq!(attestation.v, att.v);
+    }
+
+    #[test]
+    fn decode_attestation_from_first_header() {
+        //* Given
+        let attestation = Faker.fake::<Attestation>();
+
+        let header = {
+            let value = serde_json::to_string(&AttestationSerde::from(&attestation)).unwrap();
+            HeaderValue::from_str(&value).unwrap()
+        };
+        let headers = [
+            header,
+            HeaderValue::from_static("invalid"),
+            HeaderValue::from_static(""),
+        ];
+
+        //* When
+        let result = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn fail_decode_attestation_from_empty_string_header() {
+        //* Given
+        let header = HeaderValue::from_static("");
+        let headers = [header];
+
+        //* When
+        let result = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fail_decode_attestation_from_invalid_header() {
+        //* Given
+        let header = HeaderValue::from_static("invalid");
+        let headers = [header];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        assert!(header.is_err());
+    }
+
+    #[test]
+    fn fail_decode_attestation_if_no_headers() {
+        //* Given
+        let headers = [];
+
+        //* When
+        let header = GraphAttestation::decode(&mut headers.iter());
+
+        //* Then
+        assert!(header.is_err());
+    }
+}

--- a/thegraph-headers/src/graph_indexed.rs
+++ b/thegraph-headers/src/graph_indexed.rs
@@ -1,0 +1,58 @@
+//! An HTTP _typed header_ for the `graph-indexed` header.
+//!
+//! The `graph-indexed` header contains a JSON-encoded [`BlockInfo`] struct indicating the latest
+//! indexed block information.
+
+use headers::{Error as HeaderError, Header, HeaderName, HeaderValue};
+use thegraph_core::alloy::primitives::{BlockHash, BlockNumber};
+
+/// The HTTP header name for the `graph-indexed` header.
+pub const HEADER_NAME: &str = "graph-indexed";
+
+/// An HTTP _typed header_ for the `graph-indexed` header.
+///
+/// The `graph-indexed` header contains a JSON-encoded [`BlockInfo`] struct indicating the latest
+/// indexed block information.
+pub struct GraphIndexed(pub BlockInfo);
+
+impl Header for GraphIndexed {
+    fn name() -> &'static HeaderName {
+        static HTTP_HEADER_NAME: HeaderName = HeaderName::from_static(HEADER_NAME);
+        &HTTP_HEADER_NAME
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, HeaderError>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let value = values.next().ok_or_else(HeaderError::invalid)?;
+        let info = serde_json::from_slice::<'_, BlockInfo>(value.as_bytes())
+            .map_err(|_| HeaderError::invalid())?;
+        Ok(Self(info))
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        let bytes = serde_json::to_vec(&self.0).expect("header to be valid json");
+        let value = HeaderValue::from_bytes(&bytes).expect("header to be valid utf-8");
+        values.extend(std::iter::once(value));
+    }
+}
+
+/// A struct containing information about the latest block.
+///
+/// Type ported from the Graph Node.
+///
+/// See Graph Node's [`LatestBlockInfo`][1].
+///
+/// [1]: https://github.com/graphprotocol/graph-node/blob/a8b590f7d3fbabf2968ce7ced30bfd1485ce5f31/graph/src/data/query/result.rs#L68-L74
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BlockInfo {
+    /// The hash of the latest block.
+    pub hash: BlockHash,
+    /// The number of the latest block.
+    pub number: BlockNumber,
+    /// The timestamp of the latest block.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<u64>,
+}

--- a/thegraph-headers/src/lib.rs
+++ b/thegraph-headers/src/lib.rs
@@ -1,0 +1,17 @@
+//! Common HTTP _typed headers_ used across _The Graph_ network services.
+//!
+//! See _hyper_'s [`headers`][1] crate and _axum-extra_'s [`TypedHeader`][2] extractor
+//! documentation for more information on how to use _typed headers_.
+//!
+//! [1]: https://docs.rs/headers/latest/headers/index.html
+//! [2]: https://docs.rs/axum-extra/latest/axum_extra/typed_header/struct.TypedHeader.html
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub use headers;
+
+pub mod graph_attestable;
+#[cfg(feature = "attestation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "attestation")))]
+pub mod graph_attestation;
+pub mod graph_indexed;


### PR DESCRIPTION
This pull request introduces a new crate, `thegraph-headers`, which provides common HTTP typed headers across _The Graph_ network services. The most significant changes include adding the new crate to the project, defining several HTTP headers, and implementing their encoding and decoding logic.

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R8): Added `thegraph-headers` to the list of members.
* [`thegraph-headers/Cargo.toml`](diffhunk://#diff-c903765a684c519123d80a693bb92878c05d76cdd61b709635a436fb40a99a59R1-R17): Created `thegraph-headers` crate with initial dependencies and features.

* [`thegraph-headers/src/graph_attestable.rs`](diffhunk://#diff-d628cb31edc33079c2b5ad1400746c18711bc8993d2a11de6ee730eae30eedf5R1-R47): Defined and implemented the `GraphAttestable` header, which indicates whether a response is attestable.
* [`thegraph-headers/src/graph_attestation.rs`](diffhunk://#diff-f007a4502c76128ce61254b9cade5e8ba53eaba0124e9fd60bf76da833038666R1-R203): Defined and implemented the `GraphAttestation` header, which can contain a JSON-encoded `Attestation` struct.
* [`thegraph-headers/src/graph_indexed.rs`](diffhunk://#diff-50fd35397b80dfc3f25b4c4c811b3adf84cd0aa35c15e33f1b4bc28dd6113d92R1-R58): Defined and implemented the `GraphIndexed` header, which contains a JSON-encoded `BlockInfo` struct indicating the latest indexed block information.
* [`thegraph-headers/src/lib.rs`](diffhunk://#diff-dd91a34cc431efc65cc7cdbf4a58f0b83ac9006c73beb96a620de6ca259fc1deR1-R17): Set up the main library file to include the new headers and provide documentation.