### PR TITLE
chore(thegraph-core): update msrv to 1.81.0

### DIFF
--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.81.0"
 
 [features]
 default = []

--- a/thegraph-core/README.md
+++ b/thegraph-core/README.md
@@ -11,7 +11,7 @@ Rust core modules for _The Graph_ network.
 
 ## Usage
 
-To add this crate to your project as a depenency use the `cargo add` command:
+To add this crate to your project as a dependency use the `cargo add` command:
 
 ```shell
 cargo add thegraph-core


### PR DESCRIPTION
This pull request includes updates to the `thegraph-core` crate, specifically addressing a version upgrade and a typo fix.

* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77L9-R9): Updated the `rust-version` from "1.79.0" to "1.81.0".