### PR TITLE
feat(thegraph-graphql-http): rename features to match optional deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ resolver = "2"
 members = [
     "graphql",
     "thegraph-core",
-    "thegraph-graphql-http",
     "thegraph-client-subgraphs",
+    "thegraph-graphql-http",
 ]

--- a/thegraph-client-subgraphs/Cargo.toml
+++ b/thegraph-client-subgraphs/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = { version = "0.12.9", features = ["json"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = { version = "1.0.132", features = ["raw_value"] }
 thegraph-core = { version = "0.9.1", path = "../thegraph-core", features = ["serde"] }
-thegraph-graphql-http = { version = "0.2.4", path = "../thegraph-graphql-http", features = ["http-client-reqwest"] }
+thegraph-graphql-http = { version = "0.2.4", path = "../thegraph-graphql-http", features = ["reqwest"] }
 thiserror = "2.0.1"
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }
 url = "2.5.3"

--- a/thegraph-graphql-http/Cargo.toml
+++ b/thegraph-graphql-http/Cargo.toml
@@ -6,13 +6,13 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.71.1"
+rust-version = "1.81.0"
 
 [features]
-http-client-reqwest = ["dep:async-trait", "dep:reqwest"]
-compat-graphql-client = ["dep:graphql_client"]
-compat-graphql-parser = ["dep:graphql-parser"]
-compat-async-graphql = ["dep:async-graphql"]
+reqwest = ["dep:async-trait", "dep:reqwest"]
+graphql-client = ["dep:graphql_client"]
+graphql-parser = ["dep:graphql-parser"]
+async-graphql = ["dep:async-graphql"]
 
 [dependencies]
 async-graphql = { version = "7.0", optional = true }

--- a/thegraph-graphql-http/src/compat.rs
+++ b/thegraph-graphql-http/src/compat.rs
@@ -1,4 +1,6 @@
-#[cfg(feature = "compat-graphql-parser")]
+//! Compatibility layer for third-party GraphQL libraries.
+
+#[cfg(feature = "graphql-parser")]
 pub mod compat_graphql_parser {
     use graphql_parser::query::Text;
 
@@ -16,7 +18,7 @@ pub mod compat_graphql_parser {
     }
 }
 
-#[cfg(feature = "compat-graphql-client")]
+#[cfg(feature = "graphql-client")]
 pub mod compat_graphql_client {
     use graphql_client::QueryBody;
 
@@ -58,7 +60,7 @@ pub mod compat_graphql_client {
     }
 }
 
-#[cfg(feature = "compat-async-graphql")]
+#[cfg(feature = "async-graphql")]
 pub mod compat_async_graphql {
     use async_graphql::Request;
 

--- a/thegraph-graphql-http/src/http_client.rs
+++ b/thegraph-graphql-http/src/http_client.rs
@@ -1,14 +1,14 @@
 //! HTTP client extensions.
 
-#[cfg(feature = "http-client-reqwest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http-client-reqwest")))]
+#[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub use reqwest_ext::ReqwestExt;
 
 use crate::http::response::{Error, ResponseBody};
 
 /// The error type returned by `ReqwestExt`
-#[cfg(feature = "http-client-reqwest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http-client-reqwest")))]
+#[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 #[derive(thiserror::Error, Debug)]
 pub enum RequestError {
     /// An error occurred while serializing the GraphQL request.
@@ -78,7 +78,7 @@ where
     }
 }
 
-#[cfg(feature = "http-client-reqwest")]
+#[cfg(feature = "reqwest")]
 mod reqwest_ext {
     use async_trait::async_trait;
     use reqwest::header::{ACCEPT, CONTENT_TYPE};
@@ -90,7 +90,8 @@ mod reqwest_ext {
     };
 
     /// An extension trait for reqwest::RequestBuilder.
-    #[cfg_attr(docsrs, doc(cfg(feature = "http-client-reqwest")))]
+    #[cfg(feature = "reqwest")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
     #[async_trait]
     pub trait ReqwestExt {
         /// Sets the `Content-Type` and `Accept` headers to the GraphQL-over-HTTP media types and
@@ -102,7 +103,7 @@ mod reqwest_ext {
             Self: Sized;
 
         /// Runs a GraphQL query with the parameters in RequestBuilder, deserializes
-        /// the and returns the result.
+        /// the body and returns the result.
         async fn send_graphql<ResponseData>(
             self,
             req: impl IntoRequestParameters + Send,
@@ -111,6 +112,8 @@ mod reqwest_ext {
             ResponseData: serde::de::DeserializeOwned;
     }
 
+    #[cfg(feature = "reqwest")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
     #[async_trait]
     impl ReqwestExt for reqwest::RequestBuilder {
         fn graphql(self, req: impl IntoRequestParameters) -> Result<Self, serde_json::Error>

--- a/thegraph-graphql-http/src/lib.rs
+++ b/thegraph-graphql-http/src/lib.rs
@@ -1,13 +1,15 @@
 //! The `thegraph-graphql-http` crate provides an implementation of the GraphQL-over-HTTP protocol
-//! for The Graph network services.
+//! for _The Graph_ network services.
 //!
 //! Additionally, this crate provides a GraphQL-over-HTTP client based on this crate types and
-//! [`reqwest`]'s HTTP client. To enable this client extension, use the
-//! `http-client-reqwest` feature.
+//! [`reqwest`]'s HTTP client. To enable this client extension, use the `reqwest` feature.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod compat;
 pub mod graphql;
 pub mod http;
 
-#[cfg(feature = "http-client-reqwest")]
+#[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub mod http_client;

--- a/thegraph-graphql-http/tests/it_graphql_http_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client.rs
@@ -1,5 +1,5 @@
 //! Integration tests for the `reqwest` HTTP client based client.
-#![cfg(feature = "http-client-reqwest")]
+#![cfg(feature = "reqwest")]
 
 use std::time::Duration;
 

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
@@ -1,6 +1,6 @@
-//! Integration tests for the `thegraph-graphql-http` crate for the `compat-graphql-client`
+//! Integration tests for the `thegraph-graphql-http` crate for the `graphql-client`
 //! compatibility feature.
-#![cfg(feature = "compat-graphql-client")]
+#![cfg(all(feature = "graphql-client", feature = "reqwest"))]
 
 use std::time::Duration;
 

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
@@ -1,6 +1,6 @@
-//! Integration tests for the `thegraph-graphql-http` crate for the `compat-graphql-parser`
+//! Integration tests for the `thegraph-graphql-http` crate for the `graphql-parser`
 //! compatibility feature.
-#![cfg(feature = "compat-graphql-parser")]
+#![cfg(all(feature = "graphql-parser", feature = "reqwest"))]
 
 use std::time::Duration;
 


### PR DESCRIPTION
This pull request includes several changes to the `thegraph-graphql-http` crate, primarily focusing on renaming features and updating dependencies. The most important changes include renaming feature flags, updating the Rust version, and modifying dependencies to align with the new feature names.

### Feature Renaming and Dependency Updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L6-R7): Reordered the members list to ensure `thegraph-graphql-http` is correctly included.
* [`thegraph-client-subgraphs/Cargo.toml`](diffhunk://#diff-0131188349b5afb5c1cb3c66999bd11e519f9bc6932610041912fb37a23c1b36L17-R17): Updated the feature for `thegraph-graphql-http` dependency from `http-client-reqwest` to `reqwest`.
* [`thegraph-graphql-http/Cargo.toml`](diffhunk://#diff-52164e4c58406a76b3647261d9aaa6248f6e32ee8937bf5d49aa1ce2570362dfL9-R15): Updated the Rust version to `1.81.0` and renamed features to remove the `compat-` prefix.

### Code Adjustments for Feature Renaming:

* [`thegraph-graphql-http/src/compat.rs`](diffhunk://#diff-d7adb846aff3e96b3cbe8b52912ece533a8d11fc613952c7f4cca74a46c01dd7L1-R3): Updated feature flags in module definitions to align with the new feature names. [[1]](diffhunk://#diff-d7adb846aff3e96b3cbe8b52912ece533a8d11fc613952c7f4cca74a46c01dd7L1-R3) [[2]](diffhunk://#diff-d7adb846aff3e96b3cbe8b52912ece533a8d11fc613952c7f4cca74a46c01dd7L19-R21) [[3]](diffhunk://#diff-d7adb846aff3e96b3cbe8b52912ece533a8d11fc613952c7f4cca74a46c01dd7L61-R63)
* [`thegraph-graphql-http/src/http_client.rs`](diffhunk://#diff-f08c2a5aebd3b6b0e22831a509e19720d8c8b91409efdb1b0948124b7ab00a4eL3-R11): Renamed feature flags from `http-client-reqwest` to `reqwest` and corrected a comment typo. [[1]](diffhunk://#diff-f08c2a5aebd3b6b0e22831a509e19720d8c8b91409efdb1b0948124b7ab00a4eL3-R11) [[2]](diffhunk://#diff-f08c2a5aebd3b6b0e22831a509e19720d8c8b91409efdb1b0948124b7ab00a4eL81-R81) [[3]](diffhunk://#diff-f08c2a5aebd3b6b0e22831a509e19720d8c8b91409efdb1b0948124b7ab00a4eL93-R93) [[4]](diffhunk://#diff-f08c2a5aebd3b6b0e22831a509e19720d8c8b91409efdb1b0948124b7ab00a4eL105-R105)

### Documentation and Test Updates:

* [`thegraph-graphql-http/src/lib.rs`](diffhunk://#diff-118013c64b52198d4267124ce3ed17fa31bd075d6117457432368379d91ef11bL2-R11): Updated documentation to reflect the renamed feature flag `reqwest`.
* [`thegraph-graphql-http/tests/it_graphql_http_client.rs`](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL2-R2): Adjusted the feature flag in integration tests to `reqwest`.
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs`](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5L1-R3): Updated feature flags in integration tests to `graphql-client` and `reqwest`.
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs`](diffhunk://#diff-e2c602e6afd1a97dcbacf6e16bd826a97d1d6504582e9151928812cc989c1ae1L1-R3): Updated feature flags in integration tests to `graphql-parser` and `reqwest`.