### PR TITLE
chore(thegraph-client-subgraphs): update msrv to 1.81.0

### DIFF
--- a/thegraph-client-subgraphs/Cargo.toml
+++ b/thegraph-client-subgraphs/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.81.0"
 
 [dependencies]
 indoc = "2.0.5"


### PR DESCRIPTION
This pull request updates the `thegraph-client-subgraphs/Cargo.toml` file to use a newer version of Rust.

* Updated `rust-version` from `1.79.0` to `1.81.0` in the `thegraph-client-subgraphs/Cargo.toml` file.