### PR TITLE
chore(thegraph-graphql-http): add docs.rs package metadata configuration

### DIFF
--- a/thegraph-graphql-http/Cargo.toml
+++ b/thegraph-graphql-http/Cargo.toml
@@ -28,3 +28,7 @@ thiserror = "1.0"
 assert_matches = "1.5.0"
 indoc = "2.0.5"
 tokio = { version = "1.37.0", features = ["rt", "macros", "time"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
This pull request includes a slight change to the `thegraph-graphql-http/Cargo.toml` file. The change adds metadata for `docs.rs` to build documentation with all features enabled and specific rustdoc arguments.

Changes to documentation configuration:

* [`thegraph-graphql-http/Cargo.toml`](diffhunk://#diff-52164e4c58406a76b3647261d9aaa6248f6e32ee8937bf5d49aa1ce2570362dfR31-R34): Added `[package.metadata.docs.rs]` section to enable all features and set rustdoc arguments for `docs.rs`.