### PR TITLE
feat(thegraph-headers): add typed headers http builder extension trait

### DIFF
--- a/thegraph-headers/Cargo.toml
+++ b/thegraph-headers/Cargo.toml
@@ -13,13 +13,13 @@ attestation = ["thegraph-core/attestation"]
 
 [dependencies]
 headers = "0.4"
+http = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thegraph-core = { version = "0.9.0", path = "../thegraph-core", features = ["serde"] }
 
 [dev-dependencies]
 fake = "3.0.1"
-http = "1.2.0"
 thegraph-core = { path = "../thegraph-core", features = ["fake"] }
 
 [package.metadata.docs.rs]

--- a/thegraph-headers/src/http_ext.rs
+++ b/thegraph-headers/src/http_ext.rs
@@ -1,0 +1,69 @@
+use headers::{Header, HeaderMapExt as _};
+
+/// An extension trait adding "typed" methods to `http::request::Builder` and
+/// `http::response::Builder`.
+pub trait HttpBuilderExt: sealed::Sealed {
+    /// Add a typed `Header` to the builder.
+    ///
+    /// This method is a convenience wrapper around `headers::HeaderMapExt::typed_insert`.
+    ///
+    /// # Example for `http::request::Builder`
+    ///
+    /// ```rust
+    /// # use headers::ContentType;
+    /// use thegraph_headers::HttpBuilderExt as _;
+    ///
+    /// let request = http::request::Builder::new()
+    ///     .header_typed(ContentType::text())
+    ///     .body(())
+    ///     .expect("failed to build request");
+    ///
+    /// assert!(request.headers().get("content-type").is_some());
+    /// ```
+    ///
+    /// # Example for `http::response::Builder`
+    ///
+    /// ```rust
+    /// # use headers::ContentType;
+    /// use thegraph_headers::HttpBuilderExt as _;
+    ///
+    /// let response = http::response::Builder::new()
+    ///     .header_typed(ContentType::text())
+    ///     .body(())
+    ///     .expect("failed to build response");
+    ///
+    /// assert!(response.headers().get("content-type").is_some());
+    /// ```
+    fn header_typed<H: Header>(self, header: H) -> Self;
+}
+
+impl HttpBuilderExt for http::response::Builder {
+    #[inline]
+    fn header_typed<H: Header>(mut self, header: H) -> Self {
+        // When the builder has error, skip adding the header
+        if let Some(headers) = self.headers_mut() {
+            headers.typed_insert(header);
+        }
+
+        self
+    }
+}
+
+impl HttpBuilderExt for http::request::Builder {
+    #[inline]
+    fn header_typed<H: Header>(mut self, header: H) -> Self {
+        // When the builder has error, skip adding the header
+        if let Some(headers) = self.headers_mut() {
+            headers.typed_insert(header);
+        }
+
+        self
+    }
+}
+
+/// Sealed trait to prevent downstream implementations of `HttpBuilderExt`.
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for http::request::Builder {}
+    impl Sealed for http::response::Builder {}
+}

--- a/thegraph-headers/src/lib.rs
+++ b/thegraph-headers/src/lib.rs
@@ -15,3 +15,6 @@ pub mod graph_attestable;
 #[cfg_attr(docsrs, doc(cfg(feature = "attestation")))]
 pub mod graph_attestation;
 pub mod graph_indexed;
+mod http_ext;
+
+pub use http_ext::HttpBuilderExt;


### PR DESCRIPTION
This pull request introduces new functionality for handling HTTP headers more type-safely and updates dependencies accordingly. The most significant changes include adding a new extension trait for HTTP builders, updating the `Cargo.toml` to reflect the new dependency, and exposing the new trait in the library's main module.

* [`thegraph-headers/src/http_ext.rs`](diffhunk://#diff-4a4cbbb78c95273e26852ecd5a9a47934bda4fbcf8b68ad88d7e1c3e075b1d9eR1-R73): Introduced the `HttpBuilderExt` trait, which adds the `header_typed` method for both `http::request::Builder` and `http::response::Builder`. This method allows adding typed headers more ergonomically.