### PR TITLE
feat(thegraph-core): add more conversion trait implementations

### DIFF
--- a/thegraph-core/src/subgraph_id.rs
+++ b/thegraph-core/src/subgraph_id.rs
@@ -29,6 +29,7 @@ pub enum ParseSubgraphIdError {
     feature = "serde",
     derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
 )]
+#[repr(transparent)]
 pub struct SubgraphId(B256);
 
 impl SubgraphId {
@@ -42,6 +43,49 @@ impl SubgraphId {
     pub const fn new(value: B256) -> Self {
         Self(value)
     }
+
+    /// Get the bytes of the [`SubgraphId`] as a slice.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<B256> for SubgraphId {
+    fn as_ref(&self) -> &B256 {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for SubgraphId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<[u8; 32]> for SubgraphId {
+    fn as_ref(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
+
+impl std::borrow::Borrow<[u8]> for SubgraphId {
+    fn borrow(&self) -> &[u8] {
+        self.0.borrow()
+    }
+}
+
+impl std::borrow::Borrow<[u8; 32]> for SubgraphId {
+    fn borrow(&self) -> &[u8; 32] {
+        self.0.borrow()
+    }
+}
+
+impl std::ops::Deref for SubgraphId {
+    type Target = B256;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<B256> for SubgraphId {
@@ -52,7 +96,21 @@ impl From<B256> for SubgraphId {
 
 impl From<[u8; 32]> for SubgraphId {
     fn from(value: [u8; 32]) -> Self {
-        Self(B256::from(value))
+        Self(value.into())
+    }
+}
+
+impl<'a> From<&'a [u8; 32]> for SubgraphId {
+    fn from(value: &'a [u8; 32]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for SubgraphId {
+    type Error = <B256 as TryFrom<&'a [u8]>>::Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        value.try_into().map(Self)
     }
 }
 
@@ -65,12 +123,6 @@ impl From<SubgraphId> for B256 {
 impl From<&SubgraphId> for B256 {
     fn from(id: &SubgraphId) -> Self {
         id.0
-    }
-}
-
-impl AsRef<B256> for SubgraphId {
-    fn as_ref(&self) -> &B256 {
-        &self.0
     }
 }
 
@@ -156,8 +208,7 @@ impl std::fmt::Debug for SubgraphId {
 /// ```
 impl fake::Dummy<fake::Faker> for SubgraphId {
     fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        let bytes = <[u8; 32]>::dummy_with_rng(config, rng);
-        Self(B256::new(bytes))
+        <[u8; 32]>::dummy_with_rng(config, rng).into()
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `thegraph-core/src/deployment_id.rs` and `thegraph-core/src/subgraph_id.rs` files to improve the handling and conversion of `DeploymentId` and `SubgraphId` types. The most significant changes include adding new trait implementations, removing redundant functions, and modifying test cases.

### Changes to `DeploymentId`:

* Added `From<hex::FromHexError>` implementation for `ParseDeploymentIdError` to handle hex parsing errors more gracefully.
* Introduced new trait implementations for `DeploymentId`, including `AsRef<[u8]>`, `AsRef<[u8; 32]>`, `std::borrow::Borrow<[u8]>`, and `std::ops::Deref` for better interoperability. [[1]](diffhunk://#diff-27a2f380f335b2b2b698c5d722b5ccc50425f900e99497ae58ea827028f1dcfaR74-R105) [[2]](diffhunk://#diff-27a2f380f335b2b2b698c5d722b5ccc50425f900e99497ae58ea827028f1dcfaL67-R128)
* Removed the `parse_hex_str` function and updated the `from_str` method to use `hex::FromHex::from_hex` directly. [[1]](diffhunk://#diff-27a2f380f335b2b2b698c5d722b5ccc50425f900e99497ae58ea827028f1dcfaL225-L235) [[2]](diffhunk://#diff-27a2f380f335b2b2b698c5d722b5ccc50425f900e99497ae58ea827028f1dcfaL88-R164)
* Updated test cases by removing tests for the deleted `parse_hex_str` function.

### Changes to `SubgraphId`:

* Added similar trait implementations for `SubgraphId` as for `DeploymentId`, including `AsRef<[u8]>`, `AsRef<[u8; 32]>`, `std::borrow::Borrow<[u8]>`, and `std::ops::Deref`. [[1]](diffhunk://#diff-3a307cd6e59fce3966e151fe970b8bfdae1a2c0919098c870c03465e9fa2daa2R46-R88) [[2]](diffhunk://#diff-3a307cd6e59fce3966e151fe970b8bfdae1a2c0919098c870c03465e9fa2daa2L55-R113)
* Removed redundant `AsRef<B256>` implementation for `SubgraphId`.