### PR TITLE
chore(thegraph-headers): loose dependencies version requirements

### DIFF
--- a/thegraph-headers/Cargo.toml
+++ b/thegraph-headers/Cargo.toml
@@ -16,7 +16,7 @@ headers = "0.4"
 http = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thegraph-core = { version = "0.9.0", path = "../thegraph-core", features = ["serde"] }
+thegraph-core = { version = "0.9", path = "../thegraph-core", features = ["serde"] }
 
 [dev-dependencies]
 fake = "3.0.1"


### PR DESCRIPTION
This pull request includes a minor update to the version specification of `thegraph-core` in the `thegraph-headers/Cargo.toml` file. The change simplifies the version number to ensure compatibility with other dependencies.

Version update:

* [`thegraph-headers/Cargo.toml`](diffhunk://#diff-c903765a684c519123d80a693bb92878c05d76cdd61b709635a436fb40a99a59L19-R19): Updated `thegraph-core` version from "0.9.0" to "0.9" to simplify the version specification.