### PR TITLE
chore(thegraph-client-subgraphs): loose dependencies version requirements

### DIFF
--- a/thegraph-client-subgraphs/Cargo.toml
+++ b/thegraph-client-subgraphs/Cargo.toml
@@ -13,7 +13,7 @@ indoc = "2.0.5"
 reqwest = { version = "0.12.9", features = ["json"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = { version = "1.0.132", features = ["raw_value"] }
-thegraph-core = { version = "0.9.1", path = "../thegraph-core", features = ["serde"] }
+thegraph-core = { version = "0.9", path = "../thegraph-core", features = ["serde"] }
 thegraph-graphql-http = { version = "0.3.2", path = "../thegraph-graphql-http", features = ["reqwest"] }
 thiserror = "2.0.1"
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }


### PR DESCRIPTION
This pull request includes a change to the version of `thegraph-core` in the `thegraph-client-subgraphs/Cargo.toml` file to ensure compatibility with other dependencies.

Dependency update:

* [`thegraph-client-subgraphs/Cargo.toml`](diffhunk://#diff-0131188349b5afb5c1cb3c66999bd11e519f9bc6932610041912fb37a23c1b36L16-R16): Changed the version of `thegraph-core` from "0.9.1" to "0.9" to maintain consistency and compatibility with the project's requirements.