### PR TITLE
fix(thegraph-core): reexport signed message additional types

### DIFF
--- a/thegraph-core/src/signed_message.rs
+++ b/thegraph-core/src/signed_message.rs
@@ -76,7 +76,7 @@
 mod message;
 mod signing;
 
-pub use message::{SignedMessage, ToSolStruct};
+pub use message::{MessageHash, SignatureBytes, SignedMessage, ToSolStruct};
 pub use signing::{
     recover_signer_address, sign, verify, RecoverSignerError, SigningError, VerificationError,
 };


### PR DESCRIPTION
This pull request includes modifying the `thegraph-core/src/signed_message.rs` file to enhance the functionality of the module exports.

Module export changes:

* [`thegraph-core/src/signed_message.rs`](diffhunk://#diff-4b04ff6c1621a5e95daf139e1f94bf9ad52966f6ad7d40808245058afbacc8f6L79-R79): Added `MessageHash` and `SignatureBytes` to the list of exported items from the `message` module.