### PR TITLE
chore(thegraph-graphql-http): disable tests due to unavailable test dependency

### DIFF
--- a/thegraph-graphql-http/tests/it_graphql_http_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client.rs
@@ -18,6 +18,7 @@ use thegraph_graphql_http::{
 const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
 
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_no_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -86,6 +87,7 @@ async fn send_valid_graphql_request_no_variables() {
 }
 
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_with_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -159,6 +161,7 @@ async fn send_valid_graphql_request_with_variables() {
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Document-parsing-failure
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_invalid_request_document_parsing_failure() {
     //* Given
     let client = reqwest::Client::new();
@@ -186,6 +189,7 @@ async fn send_invalid_request_document_parsing_failure() {
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Field-errors-encountered-during-execution
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_invalid_request_field_errors_encountered_during_execution_failure() {
     //* Given
     let client = reqwest::Client::new();
@@ -226,6 +230,7 @@ async fn send_invalid_request_field_errors_encountered_during_execution_failure(
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Operation-cannot-be-determined
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_invalid_request_operation_cannot_be_determined_failure_null_operation_name() {
     //* Given
     let client = reqwest::Client::new();
@@ -283,6 +288,7 @@ async fn send_invalid_request_operation_cannot_be_determined_failure_null_operat
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Operation-cannot-be-determined
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_invalid_request_operation_cannot_be_determined_failure_invalid_operation_name() {
     //* Given
     let client = reqwest::Client::new();
@@ -342,6 +348,7 @@ async fn send_invalid_request_operation_cannot_be_determined_failure_invalid_ope
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Variable-coercion-failure
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_invalid_request_variable_coercion_failure() {
     //* Given
     let client = reqwest::Client::new();


### PR DESCRIPTION
This pull request includes changes to the `thegraph-graphql-http/tests/it_graphql_http_client.rs` file to mark several tests as ignored due to the test server being unavailable. These changes ensure the test suite does not fail due to external dependencies.

* `thegraph-graphql-http/tests/it_graphql_http_client.rs`: Added `#[ignore = "Test server unavailable"]` annotation to the following test functions:
  * `send_valid_graphql_request_no_variables`
  * `send_valid_graphql_request_with_variables`
  * `send_invalid_request_document_parsing_failure`
  * `send_invalid_request_field_errors_encountered_during_execution_failure`
  * `send_invalid_request_operation_cannot_be_determined_failure_null_operation_name`
  * `send_invalid_request_operation_cannot_be_determined_failure_invalid_operation_name`
  * `send_invalid_request_variable_coercion_failure`