### PR TITLE
chore(thegraph-graphql-http): disable tests due to unavailable test dependency (II)

### DIFF
--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
@@ -34,6 +34,7 @@ mod test_queries {
 }
 
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_no_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -102,6 +103,7 @@ async fn send_valid_graphql_request_no_variables() {
 }
 
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_with_variables() {
     //* Given
     let client = reqwest::Client::new();

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
@@ -19,6 +19,7 @@ use thegraph_graphql_http::{
 const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
 
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_no_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -88,6 +89,7 @@ async fn send_valid_graphql_request_no_variables() {
 }
 
 #[tokio::test]
+#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_with_variables() {
     //* Given
     let client = reqwest::Client::new();


### PR DESCRIPTION
This pull request includes changes to the `thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs` file, specifically marking two test functions to be ignored due to the unavailability of the test server.

* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs`](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5R37): Added `#[ignore = "Test server unavailable"]` attribute to the `send_valid_graphql_request_no_variables` test function.
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs`](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5R106): Added `#[ignore = "Test server unavailable"]` attribute to the `send_valid_graphql_request_with_variables` test function.