### PR TITLE
chore(deps): update rust crate thiserror to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,7 +4518,7 @@ dependencies = [
  "fake",
  "serde",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.10",
 ]
 
 [[package]]

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -34,7 +34,7 @@ bs58 = "0.5"
 fake = { version = "3.0", optional = true }
 serde = { version = "1.0", optional = true }
 serde_with = { version = "3.8", optional = true }
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 alloy = { version = "0.8", features = ["signer-local"] }


### PR DESCRIPTION
This pull request includes a version upgrade for the `thiserror` dependency in the `thegraph-core/Cargo.toml` file. 

* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77L37-R37): Updated the `thiserror` dependency from version `1.0` to `2.0`.