### PR TITLE
feat(thegraph-core): add fake_impl module and alloy fake support

### DIFF
--- a/thegraph-core/src/allocation_id.rs
+++ b/thegraph-core/src/allocation_id.rs
@@ -196,9 +196,9 @@ impl serde::Serialize for AllocationId {
 /// println!("AllocationId: {:#x}", allocation_id);
 /// ```
 impl fake::Dummy<fake::Faker> for AllocationId {
-    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        let bytes = <[u8; 20]>::dummy_with_rng(config, rng);
-        Self(Address::from(bytes))
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+        use crate::fake_impl::alloy::Alloy;
+        Self(Address::dummy_with_rng(&Alloy, rng))
     }
 }
 

--- a/thegraph-core/src/fake_impl.rs
+++ b/thegraph-core/src/fake_impl.rs
@@ -1,0 +1,2 @@
+//! Implementation of the [`fake`] crate traits for generating random test data.
+pub mod alloy;

--- a/thegraph-core/src/fake_impl/alloy.rs
+++ b/thegraph-core/src/fake_impl/alloy.rs
@@ -1,0 +1,126 @@
+//! Implementation of the [`fake`] crate for generating random test data for different [`alloy`]
+//! crate types.
+//!
+//! ```rust
+//! use fake::Fake;
+//! use thegraph_core::{
+//!    alloy::primitives::{Address, B256, PrimitiveSignature, U256},
+//!    fake_impl::alloy::Alloy
+//! };
+//!
+//! // Generate random bytes
+//! let bytes: B256 = Alloy.fake();
+//!
+//! // Generate random U256 value
+//! let value: U256 = Alloy.fake();
+//!
+//! // Generate random address
+//! let address: Address = Alloy.fake();
+//!
+//! // Generate random PrimitiveSignature
+//! let signature: PrimitiveSignature = Alloy.fake();
+//!
+//! // etc.
+//! ```
+
+/// The `Alloy` struct is used to implement the [`fake::Dummy`] trait for the `alloy` crate types.
+pub struct Alloy;
+
+#[doc(hidden)]
+pub mod primitives {
+    use alloy::primitives::{Address, PrimitiveSignature, B128, B256, U256};
+    use fake::{Dummy, Faker, Rng};
+
+    use super::Alloy;
+
+    impl Dummy<Alloy> for B128 {
+        /// Generate a random [`B128`] value.
+        ///
+        /// ```rust
+        /// # use fake::Fake;
+        /// use thegraph_core::{
+        ///     alloy::primitives::B128,
+        ///     fake_impl::alloy::Alloy
+        /// };
+        ///
+        /// let value: B128 = Alloy.fake();
+        /// # assert_ne!(value, B128::ZERO);
+        /// ```
+        fn dummy_with_rng<R: Rng + ?Sized>(_: &Alloy, rng: &mut R) -> Self {
+            <[u8; 16]>::dummy_with_rng(&Faker, rng).into()
+        }
+    }
+
+    impl Dummy<Alloy> for B256 {
+        /// Generate a random [`B256`] value.
+        ///
+        /// ```rust
+        /// # use fake::Fake;
+        /// use thegraph_core::{
+        ///     alloy::primitives::B256,
+        ///     fake_impl::alloy::Alloy
+        /// };
+        ///
+        /// let value: B256 = Alloy.fake();
+        /// # assert_ne!(value, B256::ZERO);
+        /// ```
+        fn dummy_with_rng<R: Rng + ?Sized>(_: &Alloy, rng: &mut R) -> Self {
+            <[u8; 32]>::dummy_with_rng(&Faker, rng).into()
+        }
+    }
+
+    impl Dummy<Alloy> for U256 {
+        /// Generate a random [`U256`] value.
+        ///
+        /// ```rust
+        /// # use fake::Fake;
+        /// use thegraph_core::{
+        ///     alloy::primitives::U256,
+        ///     fake_impl::alloy::Alloy
+        /// };
+        ///
+        /// let value: U256 = Alloy.fake();
+        /// # assert_ne!(value, U256::ZERO);
+        fn dummy_with_rng<R: Rng + ?Sized>(_: &Alloy, rng: &mut R) -> Self {
+            U256::from_be_bytes(<[u8; 32]>::dummy_with_rng(&Faker, rng))
+        }
+    }
+
+    impl Dummy<Alloy> for Address {
+        /// Generate a random [`Address`] value.
+        /// ```rust
+        /// # use fake::Fake;
+        /// use thegraph_core::{
+        ///     alloy::primitives::Address,
+        ///     fake_impl::alloy::Alloy
+        /// };
+        ///
+        /// let value: Address = Alloy.fake();
+        /// # assert_ne!(value, Address::ZERO);
+        /// ```
+        fn dummy_with_rng<R: Rng + ?Sized>(_: &Alloy, rng: &mut R) -> Self {
+            <[u8; 20]>::dummy_with_rng(&Faker, rng).into()
+        }
+    }
+
+    impl Dummy<Alloy> for PrimitiveSignature {
+        /// Generate a random [`PrimitiveSignature`] value.
+        ///
+        /// ```rust
+        /// # use fake::Fake;
+        /// use thegraph_core::{
+        ///     alloy::primitives::PrimitiveSignature,
+        ///     fake_impl::alloy::Alloy
+        /// };
+        ///
+        /// let value: PrimitiveSignature = Alloy.fake();
+        /// ```
+        fn dummy_with_rng<R: Rng + ?Sized>(config: &Alloy, rng: &mut R) -> Self {
+            PrimitiveSignature::from_scalars_and_parity(
+                B256::dummy_with_rng(config, rng),
+                B256::dummy_with_rng(config, rng),
+                rng.gen(),
+            )
+        }
+    }
+}

--- a/thegraph-core/src/indexer_id.rs
+++ b/thegraph-core/src/indexer_id.rs
@@ -197,9 +197,9 @@ impl serde::Serialize for IndexerId {
 /// println!("IndexerId: {:#x}", indexer_id);
 /// ```
 impl fake::Dummy<fake::Faker> for IndexerId {
-    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        let bytes = <[u8; 20]>::dummy_with_rng(config, rng);
-        Self(Address::from(bytes))
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+        use crate::fake_impl::alloy::Alloy;
+        Self(Address::dummy_with_rng(&Alloy, rng))
     }
 }
 

--- a/thegraph-core/src/lib.rs
+++ b/thegraph-core/src/lib.rs
@@ -51,6 +51,9 @@ mod allocation_id;
 pub mod attestation;
 mod block;
 mod deployment_id;
+#[cfg(feature = "fake")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fake")))]
+pub mod fake_impl;
 mod indexer_id;
 mod proof_of_indexing;
 #[cfg(feature = "signed-message")]


### PR DESCRIPTION
This pull request introduces a new module for generating random test data using the `fake` crate and updates existing code to utilize this new module.

New module for generating random test data:

* [`thegraph-core/src/fake_impl.rs`](diffhunk://#diff-b35af10ee88df39cebb3f65ae49efa78587d7080fbbae003afbd48789bc6bdacR1-R2): Added a new `alloy` module for implementing the `fake` crate traits.
* [`thegraph-core/src/fake_impl/alloy.rs`](diffhunk://#diff-8a1def3e6956083589e5c207af631cd9adb440d677a2c739af75031c6063608fR1-R126): Implemented the `fake` crate for generating random test data for various `alloy` crate types, including `Address`, `B256`, `PrimitiveSignature`, and `U256`.

Updates to existing code:

* [`thegraph-core/src/allocation_id.rs`](diffhunk://#diff-2e15fb7e306b4c402d0b6243c330954a6c96d1c98d82004d3594a98175119ae9L199-R201): Modified the `dummy_with_rng` implementation for `AllocationId` to use the new `Alloy` struct.
* [`thegraph-core/src/indexer_id.rs`](diffhunk://#diff-46278ae7fc17972e75fcf4e988b1cb62c3e070174ddcd7be681510e9109eac8fL200-R202): Modified the `dummy_with_rng` implementation for `IndexerId` to use the new `Alloy` struct.
* [`thegraph-core/src/lib.rs`](diffhunk://#diff-47485ed4ac689adc6116c212d831941f5119be76ac36a8d290fa4008d6616f01R54-R56): Added the new `fake_impl` module under a feature flag.