### PR TITLE
chore(thegraph-graphql-http): update test server URL

### DIFF
--- a/thegraph-graphql-http/tests/it_graphql_http_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client.rs
@@ -15,7 +15,7 @@ use thegraph_graphql_http::{
 ///
 /// This a GraphQL server that implements the [Star Wars API](https://swapi.dev/). See
 /// https://github.com/graphql/swapi-graphql for more information.
-const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
+const TEST_SERVER_URL: &str = "https://graphql.org/graphql/";
 
 #[tokio::test]
 async fn send_valid_graphql_request_no_variables() {
@@ -277,7 +277,7 @@ async fn send_invalid_request_operation_cannot_be_determined_failure_null_operat
 
     //* Then
     assert_matches!(response, Err(err) => {
-        assert!(err.to_string().contains(r#"Must provide operation name if query contains multiple operations"#));
+        assert!(err.to_string().contains(r#"Unable to detect operation AST"#));
     });
 }
 
@@ -335,8 +335,7 @@ async fn send_invalid_request_operation_cannot_be_determined_failure_invalid_ope
     //* Then
     assert_matches!(response, Err(ResponseError::Failure { errors }) => {
         assert_eq!(errors.len(), 1);
-
-        assert!(errors[0].message.contains(r#"Unknown operation named "invalidOperationName""#));
+        assert!(errors[0].message.contains(r#"Unable to detect operation AST"#));
     });
 }
 

--- a/thegraph-graphql-http/tests/it_graphql_http_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client.rs
@@ -18,7 +18,6 @@ use thegraph_graphql_http::{
 const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
 
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_no_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -87,7 +86,6 @@ async fn send_valid_graphql_request_no_variables() {
 }
 
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_with_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -161,7 +159,6 @@ async fn send_valid_graphql_request_with_variables() {
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Document-parsing-failure
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_invalid_request_document_parsing_failure() {
     //* Given
     let client = reqwest::Client::new();
@@ -189,7 +186,6 @@ async fn send_invalid_request_document_parsing_failure() {
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Field-errors-encountered-during-execution
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_invalid_request_field_errors_encountered_during_execution_failure() {
     //* Given
     let client = reqwest::Client::new();
@@ -230,7 +226,6 @@ async fn send_invalid_request_field_errors_encountered_during_execution_failure(
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Operation-cannot-be-determined
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_invalid_request_operation_cannot_be_determined_failure_null_operation_name() {
     //* Given
     let client = reqwest::Client::new();
@@ -288,7 +283,6 @@ async fn send_invalid_request_operation_cannot_be_determined_failure_null_operat
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Operation-cannot-be-determined
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_invalid_request_operation_cannot_be_determined_failure_invalid_operation_name() {
     //* Given
     let client = reqwest::Client::new();
@@ -348,7 +342,6 @@ async fn send_invalid_request_operation_cannot_be_determined_failure_invalid_ope
 
 // https://graphql.github.io/graphql-over-http/draft/#sec-application-json.Examples.Variable-coercion-failure
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_invalid_request_variable_coercion_failure() {
     //* Given
     let client = reqwest::Client::new();

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
@@ -13,7 +13,7 @@ use thegraph_graphql_http::http_client::ReqwestExt;
 ///
 /// This a GraphQL server that implements the [Star Wars API](https://swapi.dev/). See
 /// https://github.com/graphql/swapi-graphql for more information.
-const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
+const TEST_SERVER_URL: &str = "https://graphql.org/graphql/";
 
 // As `graphql_client` generates code that specifies the query, variables and response types, we
 // need to cage them under a module to avoid name collisions.

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs
@@ -34,7 +34,6 @@ mod test_queries {
 }
 
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_no_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -103,7 +102,6 @@ async fn send_valid_graphql_request_no_variables() {
 }
 
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_with_variables() {
     //* Given
     let client = reqwest::Client::new();

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
@@ -19,7 +19,6 @@ use thegraph_graphql_http::{
 const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
 
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_no_variables() {
     //* Given
     let client = reqwest::Client::new();
@@ -89,7 +88,6 @@ async fn send_valid_graphql_request_no_variables() {
 }
 
 #[tokio::test]
-#[ignore = "Test server unavailable"]
 async fn send_valid_graphql_request_with_variables() {
     //* Given
     let client = reqwest::Client::new();

--- a/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
+++ b/thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs
@@ -16,7 +16,7 @@ use thegraph_graphql_http::{
 ///
 /// This a GraphQL server that implements the [Star Wars API](https://swapi.dev/). See
 /// https://github.com/graphql/swapi-graphql for more information.
-const TEST_SERVER_URL: &str = "https://swapi-graphql.netlify.app/.netlify/functions/index";
+const TEST_SERVER_URL: &str = "https://graphql.org/graphql/";
 
 #[tokio::test]
 async fn send_valid_graphql_request_no_variables() {


### PR DESCRIPTION
This pull request updates the test server URL and re-enables several tests in the `thegraph-graphql-http` module. The most important changes include updating the `TEST_SERVER_URL` constant and removing the `ignore` attribute from multiple test functions.

### Test Server URL Update:

* [`thegraph-graphql-http/tests/it_graphql_http_client.rs`](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL18-L21): Updated `TEST_SERVER_URL` to "https://graphql.org/graphql/" from the previous "https://swapi-graphql.netlify.app/.netlify/functions/index".
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs`](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5L16-R16): Updated `TEST_SERVER_URL` to "https://graphql.org/graphql/" from the previous "https://swapi-graphql.netlify.app/.netlify/functions/index".
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs`](diffhunk://#diff-e2c602e6afd1a97dcbacf6e16bd826a97d1d6504582e9151928812cc989c1ae1L19-L22): Updated `TEST_SERVER_URL` to "https://graphql.org/graphql/" from the previous "https://swapi-graphql.netlify.app/.netlify/functions/index".

### Re-enabling Tests:

* [`thegraph-graphql-http/tests/it_graphql_http_client.rs`](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL90): Removed `ignore` attribute from several test functions, including `send_valid_graphql_request_no_variables`, `send_valid_graphql_request_with_variables`, `send_invalid_request_document_parsing_failure`, `send_invalid_request_field_errors_encountered_during_execution_failure`, `send_invalid_request_operation_cannot_be_determined_failure_null_operation_name`, `send_invalid_request_operation_cannot_be_determined_failure_invalid_operation_name`, and `send_invalid_request_variable_coercion_failure`. [[1]](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL90) [[2]](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL164) [[3]](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL192) [[4]](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL233) [[5]](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL285-L291) [[6]](diffhunk://#diff-1b09c85374e75c8d8d80d25d3ca3777159b23af15c2de7872427e9cde357d29dL344-L351)
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_client.rs`](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5L37): Removed `ignore` attribute from `send_valid_graphql_request_no_variables` and `send_valid_graphql_request_with_variables`. [[1]](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5L37) [[2]](diffhunk://#diff-0ab984a935c3a7cd2057ad1133d981826ee1c7bc0aacb9c6052712fcce6797f5L106)
* [`thegraph-graphql-http/tests/it_graphql_http_client_graphql_parser.rs`](diffhunk://#diff-e2c602e6afd1a97dcbacf6e16bd826a97d1d6504582e9151928812cc989c1ae1L92): Removed `ignore` attribute from `send_valid_graphql_request_no_variables` and `send_valid_graphql_request_with_variables`.