### PR TITLE
fix(thegraph-core): replace rng.gen() with rng.random() to fix the deprecation warning

### DIFF
--- a/thegraph-core/src/fake_impl/alloy.rs
+++ b/thegraph-core/src/fake_impl/alloy.rs
@@ -119,7 +119,7 @@ pub mod primitives {
             PrimitiveSignature::from_scalars_and_parity(
                 B256::dummy_with_rng(config, rng),
                 B256::dummy_with_rng(config, rng),
-                rng.gen(),
+                rng.random(),
             )
         }
     }


### PR DESCRIPTION
This pull request includes a small change to the `thegraph-core/src/fake_impl/alloy.rs` file. The change updates the method used to generate a random value from `rng.gen()` to `rng.random()`.