### PR TITLE
chore: set Rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ members = [
     "thegraph-graphql-http",
     "thegraph-headers",
 ]
+
+[workspace.package]
+license = "MIT"
+edition = "2024"
+rust-version = "1.85.1"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -2,8 +2,9 @@
 name = "graphql"
 description = "A collection of GraphQL related Rust modules that are share between The Graph's network services"
 version = "0.3.0"
-edition = "2021"
-rust-version = "1.61.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 firestorm = "0.5"

--- a/graphql/src/graphql.rs
+++ b/graphql/src/graphql.rs
@@ -8,8 +8,8 @@ use firestorm::profile_fn;
 pub use graphql_parser;
 use graphql_parser::query as q;
 use serde::{
-    ser::{SerializeMap, SerializeSeq},
     Deserialize, Deserializer, Serialize, Serializer,
+    ser::{SerializeMap, SerializeSeq},
 };
 
 // TODO: (Performance) may want to do zero-copy here later.

--- a/thegraph-client-subgraphs/Cargo.toml
+++ b/thegraph-client-subgraphs/Cargo.toml
@@ -4,9 +4,9 @@ description = "A client for The Graph network's Subgraphs data service"
 version = "0.1.6"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
-license = "MIT"
-edition = "2021"
-rust-version = "1.81.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 indoc = "2.0.5"

--- a/thegraph-client-subgraphs/src/client.rs
+++ b/thegraph-client-subgraphs/src/client.rs
@@ -1,15 +1,15 @@
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::{Arc, atomic::AtomicU64};
 
-use thegraph_core::{alloy::primitives::BlockNumber, BlockPointer};
+use thegraph_core::{BlockPointer, alloy::primitives::BlockNumber};
 use thegraph_graphql_http::{
     graphql::IntoDocument, http::request::IntoRequestParameters, http_client::ResponseError,
 };
-use tracing::{instrument, Instrument};
+use tracing::{Instrument, instrument};
 use url::Url;
 
 use crate::queries::{
     bootstrap::send_bootstrap_meta_query,
-    page::{send_subgraph_page_query, BlockHeight, SubgraphPageQueryResponseOpaqueEntry},
+    page::{BlockHeight, SubgraphPageQueryResponseOpaqueEntry, send_subgraph_page_query},
     send_subgraph_query,
 };
 

--- a/thegraph-client-subgraphs/src/queries/bootstrap.rs
+++ b/thegraph-client-subgraphs/src/queries/bootstrap.rs
@@ -5,7 +5,7 @@
 //! which block the query was effectively executed.
 use url::Url;
 
-use super::common::{send_query, Meta};
+use super::common::{Meta, send_query};
 
 const SUBGRAPH_META_QUERY_DOCUMENT: &str = r#"{ meta: _meta { block { number hash } } }"#;
 

--- a/thegraph-client-subgraphs/src/queries/page.rs
+++ b/thegraph-client-subgraphs/src/queries/page.rs
@@ -7,7 +7,7 @@ use thegraph_graphql_http::{
 };
 use url::Url;
 
-use super::common::{send_query, Meta};
+use super::common::{Meta, send_query};
 
 /// The block at which the query should be executed.
 ///

--- a/thegraph-client-subgraphs/src/queries/tests/it_bootstrap_query.rs
+++ b/thegraph-client-subgraphs/src/queries/tests/it_bootstrap_query.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use super::testlib::{
-    init_test_tracing, test_auth_token, test_subgraph_url, GRAPH_NETWORK_ARBITRUM_SUBGRAPH_ID,
+    GRAPH_NETWORK_ARBITRUM_SUBGRAPH_ID, init_test_tracing, test_auth_token, test_subgraph_url,
 };
 use crate::queries::bootstrap::send_bootstrap_meta_query;
 

--- a/thegraph-client-subgraphs/src/queries/tests/it_page_query.rs
+++ b/thegraph-client-subgraphs/src/queries/tests/it_page_query.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use super::testlib::{
-    init_test_tracing, test_auth_token, test_subgraph_url, GRAPH_NETWORK_ARBITRUM_SUBGRAPH_ID,
+    GRAPH_NETWORK_ARBITRUM_SUBGRAPH_ID, init_test_tracing, test_auth_token, test_subgraph_url,
 };
-use crate::queries::page::{send_subgraph_page_query, BlockHeight};
+use crate::queries::page::{BlockHeight, send_subgraph_page_query};
 
 #[test_with::env(IT_TEST_ARBITRUM_GATEWAY_URL, IT_TEST_ARBITRUM_GATEWAY_AUTH)]
 #[tokio::test]

--- a/thegraph-client-subgraphs/src/queries/tests/testlib.rs
+++ b/thegraph-client-subgraphs/src/queries/tests/testlib.rs
@@ -1,6 +1,6 @@
 //! Test helpers for the subgraph-client queries integration tests.
 
-use tracing_subscriber::{fmt::TestWriter, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::TestWriter};
 use url::Url;
 
 /// The Graph Network Arbitrum subgraph in the network.

--- a/thegraph-client-subgraphs/tests/it_client_subgraphs.rs
+++ b/thegraph-client-subgraphs/tests/it_client_subgraphs.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use thegraph_client_subgraphs::Client as SubgraphClient;
 use thegraph_core::{BlockPointer, SubgraphId};
-use tracing_subscriber::{fmt::TestWriter, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::TestWriter};
 use url::Url;
 
 /// Initialize the tests tracing subscriber.

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -4,9 +4,9 @@ description = "Rust core modules for The Graph network"
 version = "0.12.1"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
-license = "MIT"
-edition = "2021"
-rust-version = "1.81.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/thegraph-core/src/attestation.rs
+++ b/thegraph-core/src/attestation.rs
@@ -2,10 +2,10 @@
 
 use alloy::{
     primitives::{
-        b256, keccak256, normalize_v, Address, ChainId, PrimitiveSignature as Signature, B256,
+        Address, B256, ChainId, PrimitiveSignature as Signature, b256, keccak256, normalize_v,
     },
     signers::SignerSync,
-    sol_types::{eip712_domain, Eip712Domain, SolStruct},
+    sol_types::{Eip712Domain, SolStruct, eip712_domain},
 };
 
 use crate::{allocation_id::AllocationId, deployment_id::DeploymentId};
@@ -186,13 +186,13 @@ impl fake::Dummy<fake::Faker> for Attestation {
 #[cfg(test)]
 mod tests {
     use alloy::{
-        primitives::{address, b256, Address, ChainId, B256},
-        signers::{local::PrivateKeySigner, SignerSync},
+        primitives::{Address, B256, ChainId, address, b256},
+        signers::{SignerSync, local::PrivateKeySigner},
         sol_types::Eip712Domain,
     };
 
-    use super::{create, eip712_domain, verify, Attestation};
-    use crate::{deployment_id, DeploymentId};
+    use super::{Attestation, create, eip712_domain, verify};
+    use crate::{DeploymentId, deployment_id};
 
     const CHAIN_ID: ChainId = 1337;
     const DISPUTE_MANAGER_ADDRESS: Address = address!("16def7e0108a5467a106DBd7537F8591F470342e");

--- a/thegraph-core/src/deployment_id.rs
+++ b/thegraph-core/src/deployment_id.rs
@@ -352,9 +352,9 @@ pub const fn __parse_cid_v0_const(value: &str) -> B256 {
 mod tests {
     use std::str::FromStr;
 
-    use alloy::primitives::{b256, B256};
+    use alloy::primitives::{B256, b256};
 
-    use super::{format_cid_v0, parse_cid_v0_str, DeploymentId, ParseDeploymentIdError};
+    use super::{DeploymentId, ParseDeploymentIdError, format_cid_v0, parse_cid_v0_str};
     use crate::deployment_id;
 
     const VALID_CID: &str = "QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz";

--- a/thegraph-core/src/fake_impl/alloy.rs
+++ b/thegraph-core/src/fake_impl/alloy.rs
@@ -28,7 +28,7 @@ pub struct Alloy;
 
 #[doc(hidden)]
 pub mod primitives {
-    use alloy::primitives::{Address, PrimitiveSignature, B128, B256, U256};
+    use alloy::primitives::{Address, B128, B256, PrimitiveSignature, U256};
     use fake::{Dummy, Faker, Rng};
 
     use super::Alloy;

--- a/thegraph-core/src/signed_message.rs
+++ b/thegraph-core/src/signed_message.rs
@@ -78,15 +78,15 @@ mod signing;
 
 pub use message::{MessageHash, SignatureBytes, SignedMessage, ToSolStruct};
 pub use signing::{
-    recover_signer_address, sign, verify, RecoverSignerError, SigningError, VerificationError,
+    RecoverSignerError, SigningError, VerificationError, recover_signer_address, sign, verify,
 };
 
 #[cfg(test)]
 mod tests {
     use alloy::{
-        primitives::{address, b256, keccak256, PrimitiveSignature as Signature},
+        primitives::{PrimitiveSignature as Signature, address, b256, keccak256},
         signers::local::PrivateKeySigner,
-        sol_types::{eip712_domain, Eip712Domain},
+        sol_types::{Eip712Domain, eip712_domain},
     };
 
     use super::{message::SignedMessage, signing, signing::VerificationError};

--- a/thegraph-core/src/signed_message/signing.rs
+++ b/thegraph-core/src/signed_message/signing.rs
@@ -1,8 +1,8 @@
 use alloy::{
     primitives::{Address, SignatureError},
     signers::{
-        k256::ecdsa::Error as EcdsaError, Error as SignerError, SignerSync,
-        UnsupportedSignerOperation,
+        Error as SignerError, SignerSync, UnsupportedSignerOperation,
+        k256::ecdsa::Error as EcdsaError,
     },
     sol_types::{Eip712Domain, SolStruct},
 };

--- a/thegraph-core/src/subgraph_id.rs
+++ b/thegraph-core/src/subgraph_id.rs
@@ -251,7 +251,7 @@ pub const fn __parse_subgraph_id_const(value: &str) -> B256 {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{b256, B256};
+    use alloy::primitives::{B256, b256};
 
     use super::{ParseSubgraphIdError, SubgraphId};
     use crate::subgraph_id;

--- a/thegraph-graphql-http/Cargo.toml
+++ b/thegraph-graphql-http/Cargo.toml
@@ -4,9 +4,9 @@ description = "A rust implementation of the GraphQL-over-HTTP spec for The Graph
 version = "0.3.3"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
-license = "MIT"
-edition = "2021"
-rust-version = "1.81.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 reqwest = ["dep:async-trait", "dep:reqwest"]

--- a/thegraph-graphql-http/src/http_client.rs
+++ b/thegraph-graphql-http/src/http_client.rs
@@ -83,9 +83,9 @@ mod reqwest_ext {
     use async_trait::async_trait;
     use reqwest::header::{ACCEPT, CONTENT_TYPE};
 
-    use super::{process_response_body, RequestError, ResponseResult};
+    use super::{RequestError, ResponseResult, process_response_body};
     use crate::http::{
-        request::{IntoRequestParameters, GRAPHQL_REQUEST_MEDIA_TYPE},
+        request::{GRAPHQL_REQUEST_MEDIA_TYPE, IntoRequestParameters},
         response::{GRAPHQL_LEGACY_RESPONSE_MEDIA_TYPE, GRAPHQL_RESPONSE_MEDIA_TYPE},
     };
 

--- a/thegraph-headers/Cargo.toml
+++ b/thegraph-headers/Cargo.toml
@@ -4,9 +4,9 @@ description = "Common HTTP headers for _The Graph_ network services"
 version = "0.1.5"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
-license = "MIT"
-edition = "2021"
-rust-version = "1.81.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 attestation = ["thegraph-core/attestation"]


### PR DESCRIPTION

This pull request updates the `Cargo.toml` files across multiple projects to use workspace settings for the `edition`, `license`, and `rust-version` fields. This change ensures consistency and simplifies the maintenance of these configurations.

Key changes include:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10-R13): Added workspace package settings for `edition` and `license`.

Updates to individual project `Cargo.toml` files to use workspace settings:

* [`graphql/Cargo.toml`](diffhunk://#diff-aa8d8a1ff307348f1c44ba39c1d68d74cb82ec6bfbbd5014889329839c98f841L5-R7): Switched to workspace settings for `edition` and `license`, and updated `rust-version` to "1.85.0".
* [`thegraph-client-subgraphs/Cargo.toml`](diffhunk://#diff-0131188349b5afb5c1cb3c66999bd11e519f9bc6932610041912fb37a23c1b36L7-R9): Switched to workspace settings for `edition` and `license`, and updated `rust-version` to "1.85.0".
* [`thegraph-core/Cargo.toml`](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77L7-R9): Switched to workspace settings for `edition` and `license`, and updated `rust-version` to "1.85.0".
* [`thegraph-graphql-http/Cargo.toml`](diffhunk://#diff-52164e4c58406a76b3647261d9aaa6248f6e32ee8937bf5d49aa1ce2570362dfL7-R9): Switched to workspace settings for `edition` and `license`, and updated `rust-version` to "1.85.0".
* [`thegraph-headers/Cargo.toml`](diffhunk://#diff-c903765a684c519123d80a693bb92878c05d76cdd61b709635a436fb40a99a59L7-R9): Switched to workspace settings for `edition` and `license`, and updated `rust-version` to "1.85.0".