### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "thegraph-client-subgraphs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "indoc",
  "reqwest",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "thegraph-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "alloy",
  "async-graphql",
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "thegraph-headers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "fake",
  "headers",

--- a/thegraph-client-subgraphs/CHANGELOG.md
+++ b/thegraph-client-subgraphs/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/edgeandnode/toolshed/compare/thegraph-client-subgraphs-v0.2.0...thegraph-client-subgraphs-v0.3.0) - 2025-05-16
+
+### Other
+
+- updated the following local packages: thegraph-core
+
 ## [0.2.0](https://github.com/edgeandnode/toolshed/compare/thegraph-client-subgraphs-v0.1.6...thegraph-client-subgraphs-v0.2.0) - 2025-04-17
 
 ### Other

--- a/thegraph-client-subgraphs/Cargo.toml
+++ b/thegraph-client-subgraphs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thegraph-client-subgraphs"
 description = "A client for The Graph network's Subgraphs data service"
-version = "0.2.0"
+version = "0.3.0"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true
@@ -13,7 +13,7 @@ indoc = "2.0.5"
 reqwest = { version = "0.12.9", features = ["json"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = { version = "1.0.132", features = ["raw_value"] }
-thegraph-core = { version = "0.14", path = "../thegraph-core", features = ["serde"] }
+thegraph-core = { version = "0.15", path = "../thegraph-core", features = ["serde"] }
 thegraph-graphql-http = { version = "0.4.0", path = "../thegraph-graphql-http", features = ["reqwest"] }
 thiserror = "2.0.1"
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }

--- a/thegraph-core/CHANGELOG.md
+++ b/thegraph-core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/edgeandnode/toolshed/compare/thegraph-core-v0.14.0...thegraph-core-v0.15.0) - 2025-05-16
+
+### Other
+
+- *(deps)* update rust crate alloy to 1.0 ([#545](https://github.com/edgeandnode/toolshed/pull/545))
+
 ## [0.14.0](https://github.com/edgeandnode/toolshed/compare/thegraph-core-v0.12.1...thegraph-core-v0.14.0) - 2025-04-17
 
 ### Other

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thegraph-core"
 description = "Rust core modules for The Graph network"
-version = "0.14.0"
+version = "0.15.0"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true

--- a/thegraph-headers/CHANGELOG.md
+++ b/thegraph-headers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/edgeandnode/toolshed/compare/thegraph-headers-v0.2.0...thegraph-headers-v0.3.0) - 2025-05-16
+
+### Other
+
+- updated the following local packages: thegraph-core
+
 ## [0.2.0](https://github.com/edgeandnode/toolshed/compare/thegraph-headers-v0.1.5...thegraph-headers-v0.2.0) - 2025-04-17
 
 ### Other

--- a/thegraph-headers/Cargo.toml
+++ b/thegraph-headers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thegraph-headers"
 description = "Common HTTP headers for _The Graph_ network services"
-version = "0.2.0"
+version = "0.3.0"
 repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true
@@ -16,7 +16,7 @@ headers = "0.4"
 http = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thegraph-core = { version = "0.14", path = "../thegraph-core", features = ["serde"] }
+thegraph-core = { version = "0.15", path = "../thegraph-core", features = ["serde"] }
 
 [dev-dependencies]
 fake = "4.0.0"


### PR DESCRIPTION
This pull request updates the versions of several related Rust packages (`thegraph-client-subgraphs`, `thegraph-core`, and `thegraph-headers`) and their dependencies. The most significant changes include updating the `thegraph-core` dependency to version `0.15` across packages, updating the package versions themselves, and adding corresponding changelog entries.

### Dependency Updates:
* Updated the `thegraph-core` dependency from version `0.14` to `0.15` in `thegraph-client-subgraphs` (`Cargo.toml`) and `thegraph-headers` (`Cargo.toml`). [[1]](diffhunk://#diff-0131188349b5afb5c1cb3c66999bd11e519f9bc6932610041912fb37a23c1b36L16-R16) [[2]](diffhunk://#diff-c903765a684c519123d80a693bb92878c05d76cdd61b709635a436fb40a99a59L19-R19)

### Package Version Updates:
* Incremented the version of `thegraph-client-subgraphs` from `0.2.0` to `0.3.0` in `Cargo.toml`.
* Incremented the version of `thegraph-core` from `0.14.0` to `0.15.0` in `Cargo.toml`.
* Incremented the version of `thegraph-headers` from `0.2.0` to `0.3.0` in `Cargo.toml`.

### Changelog Updates:
* Added a new entry for version `0.3.0` in `thegraph-client-subgraphs/CHANGELOG.md`, noting the update to the `thegraph-core` dependency.
* Added a new entry for version `0.15.0` in `thegraph-core/CHANGELOG.md`, mentioning the update to the `alloy` crate dependency.
* Added a new entry for version `0.3.0` in `thegraph-headers/CHANGELOG.md`, noting the update to the `thegraph-core` dependency.