### PR TITLE
chore: update crates MSRV to 1.86 and 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ members = [
 [workspace.package]
 license = "MIT"
 edition = "2024"
-rust-version = "1.85.1"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -4,8 +4,8 @@ description = "A collection of GraphQL related Rust modules that are share betwe
 version = "0.3.0"
 edition.workspace = true
 license.workspace = true
-rust-version.workspace = true
 publish = false
+rust-version = "1.86"
 
 [dependencies]
 firestorm = "0.5"

--- a/thegraph-client-subgraphs/Cargo.toml
+++ b/thegraph-client-subgraphs/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.88"
 
 [dependencies]
 indoc = "2.0.5"

--- a/thegraph-core/Cargo.toml
+++ b/thegraph-core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.87"
 
 [features]
 default = []

--- a/thegraph-graphql-http/Cargo.toml
+++ b/thegraph-graphql-http/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.86"
 
 [features]
 reqwest = ["dep:async-trait", "dep:reqwest"]

--- a/thegraph-headers/Cargo.toml
+++ b/thegraph-headers/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/edgeandnode/toolshed"
 authors = ["Lorenzo Delgado (LNSD) <lorenzo@edgeandnode.com>"]
 license.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.87"
 
 [features]
 attestation = ["thegraph-core/attestation"]


### PR DESCRIPTION
This pull request updates the minimum required Rust versions across several crates in the workspace by replacing the use of `rust-version.workspace = true` with explicit `rust-version` values in each `Cargo.toml`. This ensures that each crate specifies its own compatible Rust version, improving clarity and potentially avoiding build issues if the workspace default changes.

**Rust version specification updates:**

* Set explicit `rust-version = "1.86"` in `thegraph-graphql-http/Cargo.toml` and `graphql/Cargo.toml` [[1]](diffhunk://#diff-52164e4c58406a76b3647261d9aaa6248f6e32ee8937bf5d49aa1ce2570362dfL9-R9) [[2]](diffhunk://#diff-aa8d8a1ff307348f1c44ba39c1d68d74cb82ec6bfbbd5014889329839c98f841L7-R8)
* Set explicit `rust-version = "1.87"` in `thegraph-core/Cargo.toml` and `thegraph-headers/Cargo.toml` [[1]](diffhunk://#diff-d1587aa103511335cd0e08621b52b0ad86d5e66656db2261b213d93d80736f77L9-R9) [[2]](diffhunk://#diff-c903765a684c519123d80a693bb92878c05d76cdd61b709635a436fb40a99a59L9-R9)
* Set explicit `rust-version = "1.88"` in `thegraph-client-subgraphs/Cargo.toml`

**Workspace configuration:**

* Removed the `rust-version` field from the workspace-level `Cargo.toml`, moving responsibility to each crate